### PR TITLE
fix: fix S3 deploy path bug and upgrade to Node.js 24 actions

### DIFF
--- a/.github/workflows/infrastructure-manualcheck.yml
+++ b/.github/workflows/infrastructure-manualcheck.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
           role-to-assume: ${{ secrets.AWS_TF_OIDC_ROLE }}
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
           role-to-assume: ${{ secrets.AWS_TF_OIDC_ROLE }}

--- a/.github/workflows/infrastructure-test.yml
+++ b/.github/workflows/infrastructure-test.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
           role-to-assume: ${{ secrets.AWS_TF_OIDC_ROLE }}
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
           role-to-assume: ${{ secrets.AWS_TF_OIDC_ROLE }}

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
           role-to-assume: ${{ secrets.AWS_TF_OIDC_ROLE }}
@@ -58,10 +58,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
           role-to-assume: ${{ secrets.AWS_TF_OIDC_ROLE }}
@@ -90,10 +90,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
           role-to-assume: ${{ secrets.AWS_TF_OIDC_ROLE }}

--- a/.github/workflows/verify_s3.yml
+++ b/.github/workflows/verify_s3.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check last Terraform run status
         id: check_tf_status
@@ -56,10 +56,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
           role-to-assume: ${{ secrets.AWS_S3_OIDC_ROLE }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check last Terraform run status
         id: check_tf_status
@@ -63,11 +63,11 @@ jobs:
     if: ${{ needs.check_infrastructure.outputs.status == 'success' }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
       - name: cache node modules
         id: cache-node
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: | 
             **/node_modules
@@ -82,11 +82,11 @@ jobs:
       - setup
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
       - name: restore node modules
         id: cache-node
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: | 
             **/node_modules
@@ -106,11 +106,11 @@ jobs:
     if: ${{ needs.website_tests.result == 'success' }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
       - name: restore node modules
         id: cache-node
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: | 
             **/node_modules
@@ -126,7 +126,7 @@ jobs:
         run: npm run build-prod
 
       - name: Save cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             **/build
@@ -145,11 +145,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore cache from Prod
         if: ${{ needs.build_prod.outputs.status == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             **/build
@@ -158,7 +158,7 @@ jobs:
             ${{ runner.os }}-build-prod-
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
           role-to-assume: ${{ secrets.AWS_S3_OIDC_ROLE }}
@@ -166,9 +166,6 @@ jobs:
 
       - name: Upload to S3
         env:
-          SOURCE_DIR: website/build/prod/
           AWS_S3_BUCKET: ${{ needs.build_prod.outputs.status == 'true' && secrets.AWS_S3_BUCKET_PROD }}
-
         run: |
-          cd ${{ env.SOURCE_DIR }}
-          aws s3 cp ./* s3://${{ env.AWS_S3_BUCKET }}/ --recursive
+          aws s3 sync build/prod/ s3://${{ env.AWS_S3_BUCKET }}/ --delete


### PR DESCRIPTION
## Summary

- **Fixes website deployment failure** (closes #71): The `deploy` job was failing with `cd: website/build/prod/: No such file or directory` because `defaults: run: working-directory: website` already scopes all `run` steps to `website/`, so the path was resolving to `website/website/build/prod/`. Replaced the broken `cd + aws s3 cp ./* --recursive` with `aws s3 sync build/prod/ s3://... --delete` — cleaner, atomic, and removes stale files.
- **Upgrades all actions to Node.js 24**: GitHub Actions runners are deprecating Node.js 20 on June 2, 2026. Updated across all five workflows:
  - `actions/checkout` v4 → v6
  - `actions/setup-node` v4 → v6
  - `actions/cache` v4 → v5
  - `aws-actions/configure-aws-credentials` v4 → v5

## Test plan

- [ ] Verify website deploy job completes without `cd` error on next push to `main` targeting `website/**`
- [ ] Confirm S3 bucket receives synced files and stale assets are removed (`--delete`)
- [ ] Confirm Terraform workflows pass with updated action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)