### PR TITLE
Migrate frontend from CRA to Vite

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           path: | 
             **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}
       - name: install dependencies
         run: npm ci
 
@@ -90,7 +90,7 @@ jobs:
         with:
           path: | 
             **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}
       - name: Run Tests on Website Components
         run: npm run test
 
@@ -114,7 +114,7 @@ jobs:
         with:
           path: | 
             **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}
 
       - name: 'Create env file'
         run: |

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -47,8 +47,6 @@ build/*
 node_modules/
 jspm_packages/
 
-# Ignore Snapshots
-src/__tests__/__snapshots__/*.snap
 
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/

--- a/website/src/__tests__/SocialLinks.test.js
+++ b/website/src/__tests__/SocialLinks.test.js
@@ -3,21 +3,16 @@ import SocialLinks from '../components/social_links';
 
 // Mock the DataLoader component
 vi.mock('../utils/dataLoader', () => {
-    const generateRandomSocials = () => {
-        const numberOfSocials = Math.floor(Math.random() * 5) + 1; // Random number between 1 and 5
-        return {
-            Socials: Array.from({ length: numberOfSocials }, (_, index) => ({
-                display: true,
-                name: `Social${index + 1}`,
-                link: `http://social${index + 1}.com`,
-                logo: 'mdi:home', // Mock icon identifier
-            })),
-        };
-    };
-
     return {
         default: ({ children }) => {
-            const data = generateRandomSocials();
+            const data = {
+                Socials: Array.from({ length: 3 }, (_, index) => ({
+                    display: true,
+                    name: `Social${index + 1}`,
+                    link: `http://social${index + 1}.com`,
+                    logo: 'mdi:home',
+                })),
+            };
             return children(data);
         },
     };
@@ -30,9 +25,7 @@ describe('SocialLinks Component', () => {
         const socialLinks = screen.getAllByRole('link');
         const numberOfLinks = socialLinks.length;
 
-        // Check that the number of links is between 1 and 5
-        expect(numberOfLinks).toBeGreaterThanOrEqual(1);
-        expect(numberOfLinks).toBeLessThanOrEqual(5);
+        expect(numberOfLinks).toBe(3);
 
         socialLinks.forEach((link, index) => {
             expect(link).toHaveAttribute('href', `http://social${index + 1}.com`);

--- a/website/src/__tests__/__snapshots__/CertificationsList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/CertificationsList.test.js.snap
@@ -1,0 +1,95 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CertificationList Component > matches snapshot 1`] = `
+<div>
+  <div>
+    <div
+      class="flex flex-col gap-3"
+    >
+      <div
+        class="flex w-full justify-between gap-2"
+      >
+        <div
+          class="flex gap-4"
+        >
+          <img
+            alt="Sample Certification Logo"
+            class="h-[5.7rem] w-[5.7rem] rounded-xl"
+            src="sample_logo.png"
+          />
+          <div
+            class="flex flex-col"
+          >
+            <h3
+              class="h3 mb-0 font-extrabold text-content-title max-sm:text-sm sm:text-xs md:text-base"
+            >
+              Sample Certification
+            </h3>
+            <p
+              class="mb-0.5 font-semibold leading-snug text-content-subtitle max-sm:text-sm sm:text-xs md:text-base"
+            >
+              Sample Issuer
+            </p>
+            <p
+              class="mb-0 font-medium leading-snug text-content-date max-sm:text-xs sm:text-xs md:text-xs"
+            >
+              <strong>
+                Credential ID:
+              </strong>
+               
+              123456789
+            </p>
+            <p
+              class="mb-0 font-medium leading-snug text-content-date max-sm:text-xs sm:text-xs md:text-xs"
+            >
+              <strong>
+                Issued:
+              </strong>
+               
+              2024-05-24
+            </p>
+            <p
+              class="mb-0 font-medium leading-snug text-content-date max-sm:text-xs sm:text-xs md:text-xs"
+            >
+              <strong>
+                Expiry:
+              </strong>
+               
+              2027-05-24
+            </p>
+          </div>
+        </div>
+        <div
+          class="flex flex-wrap gap-3 max-sm:flex-col sm:flex-col"
+          id="Sample Certification Links"
+        >
+          <a
+            class="social-link"
+            href="https://samplewebsite.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              height="1.25em"
+              icon="sample-icon"
+              width="1.25em"
+            />
+          </a>
+          <a
+            class="social-link"
+            href="https://samplewebsite.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              height="1.25em"
+              icon="sample-icon"
+              width="1.25em"
+            />
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/website/src/__tests__/__snapshots__/ContentPages.test.js.snap
+++ b/website/src/__tests__/__snapshots__/ContentPages.test.js.snap
@@ -1,0 +1,103 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Content Pages > Certifications page renders correctly, calls CertificationList, and matches snapshot 1`] = `
+<div
+  class="content-block"
+  id="certifications"
+>
+  <h2
+    class="h2 mb-0 font-extrabold text-content-header"
+  >
+    CERTIFICATIONS
+  </h2>
+  <div
+    class="flex flex-col gap-8"
+  />
+</div>
+`;
+
+exports[`Content Pages > Education page renders correctly, calls EducationList, and matches snapshot 1`] = `
+<div
+  class="content-block"
+  id="education"
+>
+  <h2
+    class="h2 mb-0 font-extrabold text-content-header"
+  >
+    EDUCATION
+  </h2>
+  <div
+    class="flex flex-col gap-8"
+  />
+</div>
+`;
+
+exports[`Content Pages > Experience page renders correctly, calls ExperienceList, and matches snapshot 1`] = `
+<div
+  class="content-block"
+  id="experience"
+>
+  <h2
+    class="h2 mb-0 font-extrabold text-content-header"
+  >
+    EXPERIENCE
+  </h2>
+  <div
+    class="flex flex-col gap-8"
+  />
+</div>
+`;
+
+exports[`Content Pages > Projects page renders correctly, calls ProjectList, and matches snapshot 1`] = `
+<div
+  class="content-block"
+  id="projects"
+>
+  <h2
+    class="h2 mb-0 font-extrabold text-content-header"
+  >
+    PROJECTS
+  </h2>
+  <div
+    class="flex flex-col gap-8"
+  />
+</div>
+`;
+
+exports[`Content Pages > Skills page renders correctly, calls SkillHighlight, SkillButton, LanguageItem, and matches snapshot 1`] = `
+<div
+  class="content-block"
+  id="skills"
+>
+  <h2
+    class="h2 mb-0 font-extrabold text-content-header"
+  >
+    SKILLS
+  </h2>
+  <div
+    class="flex flex-col gap-8"
+  >
+    <div
+      class="flex flex-col gap-3"
+    />
+    <div
+      class="flex flex-col gap-3"
+    >
+      <h3
+        class="mb-0 font-extrabold leading-snug text-content-subtitle max-sm:text-sm sm:text-xs md:text-base"
+      >
+        Interested in:
+      </h3>
+    </div>
+    <div
+      class="flex flex-col gap-3"
+    >
+      <h3
+        class="mb-0 font-extrabold leading-snug text-content-subtitle max-sm:text-sm sm:text-xs md:text-base"
+      >
+        I speak
+      </h3>
+    </div>
+  </div>
+</div>
+`;

--- a/website/src/__tests__/__snapshots__/EducationList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/EducationList.test.js.snap
@@ -1,0 +1,107 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EducationList Component > matches snapshot 1`] = `
+<div>
+  <div>
+    <div
+      class="flex flex-col gap-3"
+    >
+      <div
+        class="flex w-full justify-between gap-2"
+      >
+        <div
+          class="flex gap-4"
+        >
+          <img
+            alt="Sample University Logo"
+            class="hidden h-[7rem] w-[7rem] rounded-xl sm:block"
+            src="./images/placeholder.png"
+          />
+          <div
+            class="flex flex-col"
+          >
+            <h3
+              class="h3 mb-0 font-extrabold text-content-title max-sm:text-sm sm:text-xs md:text-base"
+            >
+              Sample University
+            </h3>
+            <p
+              class="mb-0.5 font-semibold leading-snug text-content-subtitle max-sm:text-sm sm:text-xs md:text-base"
+            >
+              BSc. Sample Degree
+            </p>
+            <p
+              class="mb-0 font-medium leading-snug text-content-accent max-sm:text-xs sm:text-xs md:text-sm"
+            >
+              Sample Category
+            </p>
+            <p
+              class="mb-0 font-medium leading-snug text-content-date max-sm:text-xs sm:text-xs md:text-sm"
+            >
+              2000
+               - 
+              2004
+            </p>
+            <p
+              class="mb-0 font-light leading-snug text-content-accent max-sm:text-xs sm:text-xs md:text-xs"
+            >
+              Sample City, Country
+            </p>
+          </div>
+        </div>
+        <div
+          class="flex flex-wrap gap-3 max-sm:flex-col sm:flex-col"
+          id="Sample University Links"
+        >
+          <a
+            aria-label="program"
+            class="social-link"
+            href="https://sampleprogram.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              height="1.25em"
+              icon="fa6-solid:circle-info"
+              width="1.25em"
+            />
+          </a>
+          <a
+            aria-label="school"
+            class="social-link"
+            href="https://sampleuniversity.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              height="1.25em"
+              icon="fa6-solid:globe"
+              width="1.25em"
+            />
+          </a>
+        </div>
+      </div>
+      <div
+        class="mb-3 font-normal leading-relaxed max-sm:text-xs sm:text-xs sm:leading-relaxed md:text-sm"
+      >
+        <ul
+          class="list-disc pl-10 pr-5"
+        >
+          <li>
+            Sample detail 1
+          </li>
+          <li>
+            Sample detail 2
+          </li>
+          <li>
+            Sample detail 3
+          </li>
+          <li>
+            Sample detail 4
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/website/src/__tests__/__snapshots__/ExperienceList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/ExperienceList.test.js.snap
@@ -1,0 +1,163 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ExperienceList Component > matches snapshot 1`] = `
+<div>
+  <div
+    class="skill-list"
+  >
+    <div
+      class="flex flex-col gap-3"
+    >
+      <div
+        class="flex w-full justify-between gap-2"
+      >
+        <div
+          class="flex gap-4"
+        >
+          <img
+            alt="Generic Company logo"
+            class="hidden h-[7rem] w-[7rem] rounded-xl sm:block"
+            src="./images/placeholder.png"
+          />
+          <div
+            class="flex flex-col"
+          >
+            <h3
+              class="h3 mb-0 font-extrabold text-content-title max-sm:text-sm sm:text-xs md:text-base"
+            >
+              Generic Job Title
+            </h3>
+            <p
+              class="mb-0.5 font-semibold leading-snug text-content-subtitle max-sm:text-sm sm:text-xs md:text-base"
+            >
+              Generic Company
+            </p>
+            <p
+              class="mb-0 font-medium leading-snug text-content-accent max-sm:text-xs sm:text-xs md:text-sm"
+            >
+              Generic Type
+            </p>
+            <p
+              class="mb-0 font-medium leading-snug text-content-date max-sm:text-xs sm:text-xs md:text-sm"
+            >
+              Generic Start
+               - 
+              Generic End
+            </p>
+            <p
+              class="mb-0 font-light leading-snug text-content-accent max-sm:text-xs sm:text-xs md:text-xs"
+            >
+              Generic Location
+            </p>
+          </div>
+        </div>
+        <div
+          class="flex flex-wrap gap-3 max-sm:flex-col sm:flex-col"
+        >
+          <a
+            aria-label="Website"
+            class="social-link"
+            href="https://genericwebsite.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              height="1.25em"
+              icon="fa6-solid:globe"
+              width="1.25em"
+            />
+          </a>
+        </div>
+      </div>
+      <div
+        class="mb-3 font-normal leading-relaxed max-sm:text-xs sm:text-xs sm:leading-relaxed md:text-sm"
+      >
+        <ul
+          class="list-disc pl-10 pr-5"
+        >
+          <li>
+            Generic detail 1
+          </li>
+          <li>
+            Generic detail 2
+          </li>
+          <li>
+            Generic detail 3
+          </li>
+          <li>
+            Generic detail 4
+          </li>
+        </ul>
+      </div>
+      <div
+        class="flex flex-col gap-1.5"
+      >
+        <div
+          class="flex flex-wrap max-sm:gap-1 sm:gap-2 md:gap-3"
+        >
+          <a
+            class="skill-block"
+            href="https://genericskill1.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              class="icon-box"
+              classname="icon-box"
+              height="1.1em"
+              icon="ph:placeholder-fill"
+              width="1.1em"
+            />
+            Generic Skill 1
+          </a>
+          <a
+            class="skill-block"
+            href="https://genericskill2.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              class="icon-box"
+              classname="icon-box"
+              height="1.1em"
+              icon="ph:placeholder-fill"
+              width="1.1em"
+            />
+            Generic Skill 2
+          </a>
+          <a
+            class="skill-block"
+            href="https://genericskill3.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              class="icon-box"
+              classname="icon-box"
+              height="1.1em"
+              icon="ph:placeholder-fill"
+              width="1.1em"
+            />
+            Generic Skill 3
+          </a>
+          <a
+            class="skill-block"
+            href="https://genericskill4.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              class="icon-box"
+              classname="icon-box"
+              height="1.1em"
+              icon="ph:placeholder-fill"
+              width="1.1em"
+            />
+            Generic Skill 4
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/website/src/__tests__/__snapshots__/Home.test.js.snap
+++ b/website/src/__tests__/__snapshots__/Home.test.js.snap
@@ -1,0 +1,136 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Home component > renders properly with provided data 1`] = `
+<DocumentFragment>
+  <div
+    class="content-block"
+    id="profile"
+  >
+    <div
+      class="flex flex-col items-start gap-6 max-sm:flex-row sm:flex-row"
+    >
+      <div
+        class="flex flex-col items-center gap-4"
+      >
+        <img
+          alt="Headshot"
+          class="max-w-none rounded-lg max-sm:size-40 sm:size-40 md:size-56"
+          src="/images/placeholder.png"
+        />
+        <div
+          class="flex flex-col"
+        />
+      </div>
+      <div
+        class="flex w-full flex-col gap-5"
+      >
+        <div
+          class="flex w-full flex-col justify-between gap-2 sm:flex-row"
+        >
+          <div
+            class="w-full"
+          >
+            <h1
+              class="h1 mb-0 font-extrabold text-content-header max-sm:text-sm sm:text-sm md:text-lg"
+            >
+              John Doe
+            </h1>
+            <h2
+              class="mb-0 text-base font-medium text-content-header max-sm:text-sm sm:text-sm md:text-base"
+            >
+              Software Engineer
+            </h2>
+          </div>
+        </div>
+        <div
+          class="flex flex-col gap-6"
+        >
+          <div
+            class="inline-grid xl:grid-cols-[auto_auto]"
+          >
+            <div>
+              <span
+                class="font-medium text-content-subtitle max-sm:text-xs sm:text-sm md:text-base"
+              >
+                Location: 
+              </span>
+              <span
+                class="text-content-accent max-sm:text-xs sm:text-sm md:text-base"
+              >
+                New York, NY
+              </span>
+            </div>
+            <div>
+              <span
+                class="font-medium text-content-subtitle max-sm:text-xs sm:text-sm md:text-base"
+              />
+            </div>
+            <div>
+              <span
+                class="font-medium text-content-subtitle max-sm:text-xs sm:text-sm md:text-base"
+              >
+                Salary: 
+              </span>
+              <span
+                class="text-content-accent max-sm:text-xs sm:text-sm md:text-base"
+              >
+                <iconify-icon
+                  classname="icon-box"
+                  icon="fa6-solid:dollar-sign"
+                  inline=""
+                />
+                125,000 USD
+              </span>
+            </div>
+          </div>
+          <a
+            class="font-bold"
+            href="https://example.com/resume.pdf"
+          >
+            <button
+              class="inline-flex items-center rounded bg-primary-500 px-4 py-2 font-bold text-secondary-800 hover:bg-primary-400"
+            >
+              <div
+                class="icon-box"
+              >
+                <i
+                  class="mr-2 h-5 w-5 text-content-icons"
+                >
+                  <iconify-icon
+                    classname="icon-box mb-1"
+                    icon="fa6-solid:cloud-arrow-down"
+                    inline=""
+                  />
+                </i>
+              </div>
+              <span
+                class="text-sm text-content-header max-sm:text-xs max-sm:font-light"
+              >
+                Download CV
+              </span>
+            </button>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex flex-col gap-4"
+    >
+      <div
+        class="flex flex-wrap gap-3"
+      >
+        <div
+          class="open-for-block"
+        >
+          Available for consulting
+        </div>
+        <div
+          class="open-for-block"
+        >
+          Working on side project
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/website/src/__tests__/__snapshots__/LanguageItem.test.js.snap
+++ b/website/src/__tests__/__snapshots__/LanguageItem.test.js.snap
@@ -1,0 +1,43 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`LanguageItem renders correctly and matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="flex flex-wrap gap-3"
+  >
+    <div
+      class="skill-block"
+    >
+      <iconify-icon
+        height="1.25em"
+        icon="emojione:flag-for-united-states"
+        inline="true"
+        width="1.25em"
+      />
+      English - Native
+    </div>
+    <div
+      class="skill-block"
+    >
+      <iconify-icon
+        height="1.25em"
+        icon="twemoji:flag-for-france"
+        inline="true"
+        width="1.25em"
+      />
+      French - Intermediate
+    </div>
+    <div
+      class="skill-block"
+    >
+      <iconify-icon
+        height="1.25em"
+        icon="emojione:flag-for-spain"
+        inline="true"
+        width="1.25em"
+      />
+      Spanish - Beginner
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/website/src/__tests__/__snapshots__/ProjectList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/ProjectList.test.js.snap
@@ -1,0 +1,180 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ProjectList Component > matches snapshot 1`] = `
+<div>
+  <div>
+    <div
+      class="flex flex-col gap-6"
+    >
+      <div
+        class="flex flex-col gap-4"
+      >
+        <div
+          class="flex w-full flex-col gap-4"
+        >
+          <div
+            class="flex gap-4"
+          >
+            <img
+              alt="Generic Project logo"
+              class="hidden h-[7rem] w-[7rem] rounded-xl sm:block"
+              src="./images/generic_logo.png"
+            />
+            <div
+              class="flex w-full justify-between"
+            >
+              <div
+                class="flex flex-col"
+              >
+                <h3
+                  class="h3 mb-0 font-extrabold text-content-title max-sm:text-sm sm:text-xs md:text-base"
+                >
+                  Generic Project
+                </h3>
+                <p
+                  class="mb-0.5 font-semibold leading-snug text-content-subtitle max-sm:text-sm sm:text-xs md:text-base"
+                >
+                  Generic Company
+                </p>
+                <p
+                  class="mb-0 font-medium leading-snug text-content-accent max-sm:text-xs sm:text-xs md:text-sm"
+                >
+                  Generic Role
+                </p>
+                <p
+                  class="mb-0 font-medium leading-snug text-content-date max-sm:text-xs sm:text-xs md:text-sm"
+                >
+                  2020
+                   - 
+                  2021
+                </p>
+                <p
+                  class="mb-0 font-light leading-snug text-content-accent max-sm:text-xs sm:text-xs md:text-xs"
+                >
+                  Generic Category
+                </p>
+              </div>
+              <div
+                class="flex flex-wrap gap-3 max-sm:flex-col sm:flex-col"
+              >
+                <a
+                  aria-label="demo"
+                  class="social-link"
+                  href="https://generic-demo.com"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <iconify-icon
+                    height="1.25em"
+                    icon="fa-solid:external-link-alt"
+                    width="1.25em"
+                  />
+                </a>
+                <a
+                  aria-label="repo"
+                  class="social-link"
+                  href="https://generic-repo.com"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <iconify-icon
+                    height="1.25em"
+                    icon="simple-icons:git"
+                    width="1.25em"
+                  />
+                </a>
+                <a
+                  aria-label="spec"
+                  class="social-link"
+                  href="https://generic-spec.com"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <iconify-icon
+                    height="1.25em"
+                    icon="fa6-solid:info"
+                    width="1.25em"
+                  />
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="mb-3 font-normal leading-relaxed max-sm:text-xs sm:text-xs sm:leading-relaxed md:text-sm"
+        >
+          <ul
+            class="list-disc pl-10 pr-5"
+          >
+            <li>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </li>
+            <li>
+              Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </li>
+            <li>
+              Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+            </li>
+            <li>
+              Nisi ut aliquip ex ea commodo consequat.
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="flex flex-col gap-1.5"
+      >
+        <div
+          class="flex flex-wrap max-sm:gap-1 sm:gap-2 md:gap-3"
+        >
+          <a
+            class="skill-block"
+            href="https://generic-skill1.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              class="icon-box"
+              classname="icon-box"
+              height="1.1em"
+              icon="ph:generic-icon-1"
+              width="1.1em"
+            />
+            Generic Skill 1
+          </a>
+          <a
+            class="skill-block"
+            href="https://generic-skill2.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              class="icon-box"
+              classname="icon-box"
+              height="1.1em"
+              icon="ph:generic-icon-2"
+              width="1.1em"
+            />
+            Generic Skill 2
+          </a>
+          <a
+            class="skill-block"
+            href="https://generic-skill3.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <iconify-icon
+              class="icon-box"
+              classname="icon-box"
+              height="1.1em"
+              icon="ph:generic-icon-3"
+              width="1.1em"
+            />
+            Generic Skill 3
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/website/src/__tests__/__snapshots__/SkillButton.test.js.snap
+++ b/website/src/__tests__/__snapshots__/SkillButton.test.js.snap
@@ -1,0 +1,79 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SkillButton > renders skill buttons with correct data 1`] = `
+<DocumentFragment>
+  <div
+    class="flex flex-wrap max-sm:gap-1 sm:gap-2 md:gap-3"
+  >
+    <a
+      class="skill-block"
+      href="https://skill1.com"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <iconify-icon
+        class="icon-box"
+        classname="icon-box"
+        height="1.1em"
+        icon="skill1-icon"
+        width="1.1em"
+      />
+      Skill 1
+    </a>
+    <a
+      class="skill-block"
+      href="https://skill2.com"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <iconify-icon
+        class="icon-box"
+        classname="icon-box"
+        height="1.1em"
+        icon="skill2-icon"
+        width="1.1em"
+      />
+      Skill 2
+    </a>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SkillButton > should match manual snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="flex flex-wrap max-sm:gap-1 sm:gap-2 md:gap-3"
+  >
+    <a
+      class="skill-block"
+      href="https://skill1.com"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <iconify-icon
+        class="icon-box"
+        classname="icon-box"
+        height="1.1em"
+        icon="skill1-icon"
+        width="1.1em"
+      />
+      Skill 1
+    </a>
+    <a
+      class="skill-block"
+      href="https://skill2.com"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <iconify-icon
+        class="icon-box"
+        classname="icon-box"
+        height="1.1em"
+        icon="skill2-icon"
+        width="1.1em"
+      />
+      Skill 2
+    </a>
+  </div>
+</DocumentFragment>
+`;

--- a/website/src/__tests__/__snapshots__/SkillHighlight.test.js.snap
+++ b/website/src/__tests__/__snapshots__/SkillHighlight.test.js.snap
@@ -1,0 +1,110 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SkillHighlight > renders the skill data correctly and matches snapshot 1`] = `
+<div>
+  <div
+    class="flex flex-wrap justify-evenly gap-x-8 gap-y-2"
+  >
+    <div
+      class="flex flex-col gap-2"
+    >
+      <div
+        class="flex items-center justify-between max-sm:size-12 max-sm:justify-center max-sm:rounded-lg max-sm:bg-secondary-600 max-sm:align-middle max-sm:hover:bg-secondary-500"
+        data-tooltip-content="Skill A"
+        data-tooltip-id="skill-tooltip"
+      >
+        <a
+          class="flex items-center gap-2.5 no-underline"
+          href="https://example.com/skillA"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <iconify-icon
+            height="1.9em"
+            icon="logos:skillA"
+            inline="true"
+            width="1.9em"
+          />
+          <div
+            class="flex flex-col max-sm:hidden"
+          >
+            <span
+              class="text-content-subtitle hover:text-secondary-100 sm:text-xs sm:font-light md:text-xs md:font-semibold"
+            >
+              Skill A
+            </span>
+            <span
+              class="font-light text-content-accent sm:text-xs md:text-xs"
+            >
+              Category A
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="flex gap-1"
+      >
+        <div
+          class="skill-progress-bar-outline"
+        >
+          <div
+            class="skill-progress-bar"
+            role="progressbar"
+            style="width: 70%;"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex flex-col gap-2"
+    >
+      <div
+        class="flex items-center justify-between max-sm:size-12 max-sm:justify-center max-sm:rounded-lg max-sm:bg-secondary-600 max-sm:align-middle max-sm:hover:bg-secondary-500"
+        data-tooltip-content="Skill B"
+        data-tooltip-id="skill-tooltip"
+      >
+        <a
+          class="flex items-center gap-2.5 no-underline"
+          href="https://example.com/skillB"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <iconify-icon
+            height="1.9em"
+            icon="logos:skillB"
+            inline="true"
+            width="1.9em"
+          />
+          <div
+            class="flex flex-col max-sm:hidden"
+          >
+            <span
+              class="text-content-subtitle hover:text-secondary-100 sm:text-xs sm:font-light md:text-xs md:font-semibold"
+            >
+              Skill B
+            </span>
+            <span
+              class="font-light text-content-accent sm:text-xs md:text-xs"
+            >
+              Category B
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="flex gap-1"
+      >
+        <div
+          class="skill-progress-bar-outline"
+        >
+          <div
+            class="skill-progress-bar"
+            role="progressbar"
+            style="width: 85%;"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/website/src/__tests__/__snapshots__/SocialLinks.test.js.snap
+++ b/website/src/__tests__/__snapshots__/SocialLinks.test.js.snap
@@ -1,0 +1,61 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SocialLinks Component > matches the snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="flex gap-3"
+  >
+    <a
+      aria-label="Social1"
+      class="social-link"
+      href="http://social1.com"
+    >
+      <i
+        class="text-base text-content-icons"
+      >
+        <iconify-icon
+          class="social-link"
+          classname="social-link"
+          height="1.25em"
+          icon="mdi:home"
+          width="1.25em"
+        />
+      </i>
+    </a>
+    <a
+      aria-label="Social2"
+      class="social-link"
+      href="http://social2.com"
+    >
+      <i
+        class="text-base text-content-icons"
+      >
+        <iconify-icon
+          class="social-link"
+          classname="social-link"
+          height="1.25em"
+          icon="mdi:home"
+          width="1.25em"
+        />
+      </i>
+    </a>
+    <a
+      aria-label="Social3"
+      class="social-link"
+      href="http://social3.com"
+    >
+      <i
+        class="text-base text-content-icons"
+      >
+        <iconify-icon
+          class="social-link"
+          classname="social-link"
+          height="1.25em"
+          icon="mdi:home"
+          width="1.25em"
+        />
+      </i>
+    </a>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## Summary

- Replaces Create React App / webpack / react-scripts with Vite + Vitest, eliminating the majority of Dependabot vulnerability alerts rooted in CRA's transitive dependency tree
- Migrates `require.context` → `import.meta.glob` for dynamic JSON loading, `REACT_APP_*` env prefix → `VITE_*`, and Jest → Vitest (`vi.mock` / `vi.fn` / `vi.stubEnv`)
- Fixes CI cache key path (`hashFiles('website/package-lock.json')`) and SocialLinks non-deterministic snapshot test; commits all snapshots so CI compares against a tracked baseline

## Test plan

- [ ] `npm run test` passes locally (23/23 tests)
- [ ] CI `website_tests` job passes on this PR
- [ ] `npm run build-prod` produces `build/prod/` output without errors
- [ ] Dev server (`npm run start-dev`) loads the site correctly

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)