### PR TITLE
fix: add s3:DeleteObject to GitHub S3 deploy OIDC role

### DIFF
--- a/infrastructure/modules/iam/data.tf
+++ b/infrastructure/modules/iam/data.tf
@@ -136,6 +136,7 @@ data "aws_iam_policy_document" "crc-github-s3-actions" {
     actions = [
       "s3:PutObject",
       "s3:GetObject",
+      "s3:DeleteObject",
       "s3:ListBucket"
     ]
     resources = [


### PR DESCRIPTION
## Summary

- Adds `s3:DeleteObject` to the `crc-github-s3-actions` IAM policy attached to the OIDC role used by the website deploy workflow
- `aws s3 sync --delete` was failing with `AccessDenied` on every delete operation — old CRA static files, PDFs, and other bucket objects not present in the new build could not be removed

## Root Cause

The policy only granted `s3:PutObject`, `s3:GetObject`, and `s3:ListBucket`. The `--delete` flag requires `s3:DeleteObject` on the bucket and its objects.

## Test plan

- [ ] Terraform plan shows policy update (no destroy/recreate)
- [ ] Terraform apply succeeds
- [ ] Next website deploy: `aws s3 sync --delete` completes without `AccessDenied` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)