### PR TITLE
chore: scope GitHub Actions workflow permissions to least privilege

### DIFF
--- a/.github/workflows/infrastructure-manualcheck.yml
+++ b/.github/workflows/infrastructure-manualcheck.yml
@@ -6,9 +6,7 @@ defaults:
 
 on: workflow_dispatch
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
@@ -21,6 +19,9 @@ env:
 jobs:
   validation:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/infrastructure-test.yml
+++ b/.github/workflows/infrastructure-test.yml
@@ -14,9 +14,7 @@ on:
     paths:
       - 'infrastructure/**'
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
@@ -29,6 +27,9 @@ env:
 jobs:
   validation:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -11,9 +11,7 @@ on:
     paths:
       - 'infrastructure/**'
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
@@ -26,6 +24,9 @@ env:
 jobs:
   validation:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/verify_s3.yml
+++ b/.github/workflows/verify_s3.yml
@@ -6,14 +6,15 @@ defaults:
 
 on: workflow_dispatch
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 jobs:
   check_infrastructure:
     name: Check Terraform Status
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     outputs:
       status: ${{ steps.check_tf_status.outputs.status }}
 
@@ -53,6 +54,9 @@ jobs:
     name: Upload to S3
     runs-on: ubuntu-latest
     needs: check_infrastructure
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -11,14 +11,15 @@ on:
     paths:
       - 'website/**'
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 jobs:
   check_infrastructure:
     name: Check Terraform Status
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     outputs:
       status: ${{ steps.check_tf_status.outputs.status }}
 
@@ -59,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check_infrastructure
+    permissions:
+      contents: read
 
     if: ${{ needs.check_infrastructure.outputs.status == 'success' }}
 
@@ -69,7 +72,7 @@ jobs:
         id: cache-node
         uses: actions/cache@v5
         with:
-          path: | 
+          path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}
       - name: install dependencies
@@ -80,6 +83,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - setup
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
@@ -88,7 +93,7 @@ jobs:
         id: cache-node
         uses: actions/cache@v5
         with:
-          path: | 
+          path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}
       - name: Run Tests on Website Components
@@ -100,6 +105,8 @@ jobs:
     needs:
       - setup
       - website_tests
+    permissions:
+      contents: read
     outputs:
       status: ${{ steps.mark_prod_build_success.outputs.success }}
 
@@ -112,7 +119,7 @@ jobs:
         id: cache-node
         uses: actions/cache@v5
         with:
-          path: | 
+          path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}
 
@@ -142,6 +149,9 @@ jobs:
     needs:
       - setup
       - build_prod
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Sets `permissions: {}` at the top level of all 5 workflows (deny-all default)
- Adds explicit, minimal job-level permission grants to every job

## Permission grants by job

| Workflow | Job | Permissions |
|---|---|---|
| infrastructure / manualcheck / test | `validation` | `id-token: write`, `contents: read` |
| infrastructure / manualcheck / test | `planning` | `id-token: write`, `contents: read` (already explicit) |
| infrastructure | `deploy` | `id-token: write`, `contents: read` (already explicit) |
| verify_s3 | `check_infrastructure` | `actions: read`, `contents: read` |
| verify_s3 | `deploy` | `id-token: write`, `contents: read` |
| website | `check_infrastructure` | `actions: read`, `contents: read` |
| website | `setup` | `contents: read` |
| website | `website_tests` | `contents: read` |
| website | `build_prod` | `contents: read` |
| website | `deploy` | `id-token: write`, `contents: read` |

`actions: read` is required on `check_infrastructure` jobs that use `gh run list` to poll the Terraform workflow status.

## Test plan

- [ ] Terraform workflow runs successfully on push to `infrastructure/**`
- [ ] Website workflow runs successfully on push to `website/**`

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)