### PR TITLE
fix: pass pnpm version explicitly to action-setup

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,4 +24,3 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: always
-          retry-on-snapshot-warnings: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: always
+          retry-on-snapshot-warnings: true

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: '10.33.0'
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           cache: 'pnpm'
@@ -86,6 +88,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: '10.33.0'
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           cache: 'pnpm'
@@ -111,6 +115,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: '10.33.0'
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

`pnpm/action-setup` reads the `packageManager` field from `package.json` at the **repo root**. The `defaults.run.working-directory: website` setting only applies to `run` steps — `uses` actions always execute at the workspace root where no `package.json` exists, causing the action to fail with *"No pnpm version is specified"*.

Fix: pass `version: '10.33.0'` explicitly in the `with` block on all three `pnpm/action-setup` steps (`setup`, `website_tests`, `build_prod`).

## Test plan

- [ ] Website workflow `setup` job completes without pnpm version error
- [ ] Full pipeline runs to successful S3 deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)