### PR TITLE
chore: migrate Terraform backend lock to native S3 lockfile

### DIFF
--- a/infrastructure/backend.tf
+++ b/infrastructure/backend.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket         = "crc-s3-terraform-state-7ahwqu"
     key            = "aws-services.tfstate"
-    dynamodb_table = "crc-terraform-locks"
+    use_lockfile   = true
     region         = "us-east-1"
     encrypt        = true
   }


### PR DESCRIPTION
## Summary
- Replaces deprecated `dynamodb_table` backend parameter with `use_lockfile = true`
- State locking now uses S3 native conditional writes instead of a separate DynamoDB table
- Resolves the `Deprecated Parameter` warning introduced in Terraform v1.10

## Notes
The `crc-terraform-locks` DynamoDB table is no longer used after this applies. It can be manually deleted from AWS once confirmed stable.

Closes #75

## Test plan
- [x] Run `terraform init` locally to reinitialize the backend with the new lock config
- [x] Run `terraform plan` — should be clean with no deprecation warnings
- [ ] Confirm CI applies cleanly after merge