### PR TITLE
fix: resolve perpetual Terraform plan drift on Lambda hashes and Route53 path

### DIFF
--- a/infrastructure/modules/backend/data.tf
+++ b/infrastructure/modules/backend/data.tf
@@ -2,21 +2,24 @@
 # Begin Lambda Block #
 
 data "archive_file" "trackvisitors_lambda_function_code" {
-  type        = "zip"
-  source_file = "${path.root}/codebase/trackVisitors.py"
-  output_path = "${path.root}/codepacks/trackVisitors.zip"
+  type             = "zip"
+  source_file      = "${path.root}/codebase/trackVisitors.py"
+  output_path      = "${path.root}/codepacks/trackVisitors.zip"
+  output_file_mode = "0666"
 }
 
 data "archive_file" "cloudfrontInvalidation_lambda_function_code" {
-  type        = "zip"
-  source_file = "${path.root}/codebase/cloudfrontInvalidation.py"
-  output_path = "${path.root}/codepacks/cloudfrontInvalidation.zip"
+  type             = "zip"
+  source_file      = "${path.root}/codebase/cloudfrontInvalidation.py"
+  output_path      = "${path.root}/codepacks/cloudfrontInvalidation.zip"
+  output_file_mode = "0666"
 }
 
 data "archive_file" "sendMessage_lambda_function_code" {
-  type        = "zip"
-  source_file = "${path.root}/codebase/sendMessage.py"
-  output_path = "${path.root}/codepacks/sendMessage.zip"
+  type             = "zip"
+  source_file      = "${path.root}/codebase/sendMessage.py"
+  output_path      = "${path.root}/codepacks/sendMessage.zip"
+  output_file_mode = "0666"
 }
 
 ###################

--- a/infrastructure/modules/frontend/main.tf
+++ b/infrastructure/modules/frontend/main.tf
@@ -261,7 +261,7 @@ resource "aws_route53_health_check" "crc-website-health-check-prod" {
   reference_name    = "crc-website-prod"
   fqdn              = var.domain-name
   port              = 443
-  resource_path     = "index.html"
+  resource_path     = "/index.html"
   type              = "HTTPS"
   failure_threshold = "5"
   request_interval  = "30"


### PR DESCRIPTION
## Summary
- Adds `output_file_mode = "0666"` to all 3 `archive_file` data sources — the `archive` provider uses a fixed epoch timestamp when this is set, making zip output deterministic and stabilising `source_code_hash`
- Adds leading slash to Route53 health check `resource_path` (`index.html` → `/index.html`) to match the value AWS normalises and stores, eliminating the perpetual update diff

Closes #90

## Test plan
- [ ] `terraform plan` shows no changes to the 3 Lambda functions after first apply
- [ ] `terraform plan` shows no changes to `aws_route53_health_check` after first apply