### PR TITLE
fix: visitor counter position in navbar

### DIFF
--- a/website/src/components/navbar.jsx
+++ b/website/src/components/navbar.jsx
@@ -41,8 +41,10 @@ function Navigation() {
                     <NavItem key={item.to} {...item} />
                 ))}
                 <li aria-hidden='true' className='my-2 h-0.5 w-full bg-secondary-600 max-sm:hidden' />
+                <li>
+                    <VisitorCount />
+                </li>
             </ul>
-            <VisitorCount />
         </nav>
     );
 }


### PR DESCRIPTION
## Summary
- Visitor counter was rendering beside the nav button list instead of below it due to the `<nav>` element using `flex` (row direction by default)
- Moved `<VisitorCount />` inside the `<ul>` as an `<li>` so it stacks correctly below the divider and nav buttons

## Test plan
- [ ] Verify visitor counter appears below the navigation buttons in the sidebar
- [ ] Verify counter is hidden on mobile (`max-sm:hidden` still applies via the component itself)
- [ ] Verify counter still displays the correct visitor count