### PR TITLE
Fix certification card layout alignment across varying title heights

### DIFF
--- a/website/src/__tests__/__snapshots__/CertificationsList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/CertificationsList.test.js.snap
@@ -60,7 +60,7 @@ exports[`CertificationList Component > matches snapshot 1`] = `
           </span>
         </div>
         <dl
-          class="grid grid-cols-3 gap-2 rounded border border-dashed border-border bg-background/50 px-3 py-2 font-mono text-[0.62rem]"
+          class="mt-auto grid grid-cols-3 gap-2 rounded border border-dashed border-border bg-background/50 px-3 py-2 font-mono text-[0.62rem]"
         >
           <div
             class="flex flex-col"
@@ -106,7 +106,7 @@ exports[`CertificationList Component > matches snapshot 1`] = `
           </div>
         </dl>
         <div
-          class="mt-auto flex flex-wrap gap-2"
+          class="flex flex-wrap gap-2"
         >
           <a
             aria-label="Sample Certification – verification (opens in new tab)"

--- a/website/src/components/certification_list.jsx
+++ b/website/src/components/certification_list.jsx
@@ -42,8 +42,10 @@ const CertificationList = () => {
                                 </span>
                             </div>
 
-                            {/* validity ticket strip */}
-                            <dl className='grid grid-cols-3 gap-2 rounded border border-dashed border-border bg-background/50 px-3 py-2 font-mono text-[0.62rem]'>
+                            {/* Validity ticket strip. `mt-auto` pins it to the bottom of the
+                                card body — same trick as the link row below — so the strip and
+                                the links line up across cards whose titles wrap differently. */}
+                            <dl className='mt-auto grid grid-cols-3 gap-2 rounded border border-dashed border-border bg-background/50 px-3 py-2 font-mono text-[0.62rem]'>
                                 <div className='flex flex-col'>
                                     <dt className='uppercase tracking-wider text-content-date'>ID:</dt>
                                     <dd className='tabular truncate text-content-subtitle'>
@@ -62,7 +64,7 @@ const CertificationList = () => {
                                 </div>
                             </dl>
 
-                            <div className='mt-auto flex flex-wrap gap-2'>
+                            <div className='flex flex-wrap gap-2'>
                                 {item.links.map((linkGroup, linkIndex) =>
                                     Object.entries(linkGroup).map(
                                         ([key, link]) =>


### PR DESCRIPTION
## Summary
Adjusted the layout of certification cards to ensure the validity ticket strip and links row align consistently across cards, regardless of how their titles wrap.

## Key Changes
- Added `mt-auto` class to the validity ticket strip (`<dl>`) to pin it to the bottom of the card body, ensuring consistent vertical alignment
- Removed `mt-auto` class from the links row (`<div>`) since the validity strip now handles the spacing
- Updated the snapshot test to reflect the new class structure

## Implementation Details
The validity ticket strip and links row were previously misaligned when certification titles had different line heights due to text wrapping. By applying `mt-auto` to the validity strip instead of the links row, both elements now maintain consistent positioning across all cards. This uses the same flexbox technique that was already being applied to the links row, ensuring they line up properly at the bottom of each card regardless of title length.

https://claude.ai/code/session_01EUcEScoPGHYZZPQudwSg3N