### PR TITLE
Add Tokyo time display and service status badge to station header

### DIFF
--- a/website/src/__tests__/StationHeader.test.js
+++ b/website/src/__tests__/StationHeader.test.js
@@ -1,0 +1,64 @@
+import { act, render, screen } from '@testing-library/react';
+import StationHeader from '../components/station_header';
+
+// The bar is the site's one piece of "live" signage: it must read JST even when
+// the browser is set to another zone, and the badge must follow Tokyo's clock.
+describe('StationHeader', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const renderAt = (iso) => {
+        vi.setSystemTime(new Date(iso));
+        render(<StationHeader />);
+    };
+
+    const tick = (ms) => act(() => vi.advanceTimersByTime(ms));
+
+    test('shows Tokyo time regardless of the viewer’s zone', () => {
+        // 04:20 UTC is 13:20 JST — the clock must not follow the host TZ.
+        renderAt('2026-07-25T04:20:30Z');
+        expect(screen.getByText('13:20:30')).toBeInTheDocument();
+        expect(screen.getByLabelText('Tokyo time (JST) 13:20:30')).toBeInTheDocument();
+    });
+
+    test('ticks forward once a second', () => {
+        renderAt('2026-07-25T04:20:30Z');
+        tick(2000);
+        expect(screen.getByText('13:20:32')).toBeInTheDocument();
+    });
+
+    test('reads In Service during Tokyo working hours', () => {
+        renderAt('2026-07-25T04:20:30Z'); // 13:20 JST
+        expect(screen.getByRole('status')).toHaveTextContent('In Service');
+    });
+
+    test('reads Reduced Service on the shoulders of the day', () => {
+        renderAt('2026-07-24T22:30:00Z'); // 07:30 JST
+        expect(screen.getByRole('status')).toHaveTextContent('Reduced Service');
+    });
+
+    test('reads Last Train late in the Tokyo evening', () => {
+        renderAt('2026-07-25T13:30:00Z'); // 22:30 JST
+        expect(screen.getByRole('status')).toHaveTextContent('Last Train');
+    });
+
+    test('reads Out of Service overnight in Tokyo', () => {
+        renderAt('2026-07-25T18:00:00Z'); // 03:00 JST
+        const badge = screen.getByRole('status');
+        expect(badge).toHaveTextContent('Out of Service');
+        // The indicator stops pulsing once the line is shut.
+        expect(badge.querySelector('.animate-pulse')).toBeNull();
+    });
+
+    test('flips the badge when the clock crosses a band boundary', () => {
+        renderAt('2026-07-25T08:59:59Z'); // 17:59:59 JST
+        expect(screen.getByRole('status')).toHaveTextContent('In Service');
+        tick(1000); // 18:00:00 JST
+        expect(screen.getByRole('status')).toHaveTextContent('Reduced Service');
+    });
+});

--- a/website/src/__tests__/serviceStatus.test.js
+++ b/website/src/__tests__/serviceStatus.test.js
@@ -1,0 +1,60 @@
+import {
+    formatJstTime,
+    getJstHour,
+    getServiceLevel,
+    JST_TIME_PLACEHOLDER,
+    SERVICE_LEVELS,
+} from '../utils/serviceStatus';
+
+// The header claims to show Tokyo time and the Tokyo timetable no matter where
+// the visitor is, so these helpers are pinned against absolute UTC instants.
+describe('JST clock helpers', () => {
+    test('converts UTC instants to the Tokyo wall clock (UTC+9, no DST)', () => {
+        expect(formatJstTime(new Date('2026-07-25T00:00:00Z'))).toBe('09:00:00');
+        expect(formatJstTime(new Date('2026-07-25T15:00:00Z'))).toBe('00:00:00');
+        expect(formatJstTime(new Date('2026-07-25T14:59:59Z'))).toBe('23:59:59');
+        // January — Japan keeps UTC+9 year-round, so the offset does not move.
+        expect(formatJstTime(new Date('2026-01-15T00:30:05Z'))).toBe('09:30:05');
+    });
+
+    test('reports midnight as hour 0, never 24', () => {
+        expect(getJstHour(new Date('2026-07-25T15:00:00Z'))).toBe(0);
+        expect(formatJstTime(new Date('2026-07-25T15:00:00Z')).startsWith('00:')).toBe(true);
+    });
+
+    test('falls back to a placeholder rather than rendering an invalid date', () => {
+        expect(formatJstTime(new Date('nonsense'))).toBe(JST_TIME_PLACEHOLDER);
+        expect(getJstHour(new Date('nonsense'))).toBeNull();
+    });
+});
+
+describe('service level bands', () => {
+    // hour → the level the badge must show, checked at both ends of each band.
+    const cases = [
+        [0, SERVICE_LEVELS.closed],
+        [3, SERVICE_LEVELS.closed],
+        [5, SERVICE_LEVELS.closed],
+        [6, SERVICE_LEVELS.reduced],
+        [8, SERVICE_LEVELS.reduced],
+        [9, SERVICE_LEVELS.full],
+        [13, SERVICE_LEVELS.full],
+        [17, SERVICE_LEVELS.full],
+        [18, SERVICE_LEVELS.reduced],
+        [21, SERVICE_LEVELS.reduced],
+        [22, SERVICE_LEVELS.last],
+        [23, SERVICE_LEVELS.last],
+    ];
+
+    test.each(cases)('JST %i:00 is %o', (hour, expected) => {
+        // Build the instant from the JST hour: 00:00 JST is 15:00Z the day before.
+        const utcHour = (hour + 24 - 9) % 24;
+        const day = hour < 9 ? 24 : 25;
+        const date = new Date(`2026-07-${day}T${String(utcHour).padStart(2, '0')}:30:00Z`);
+        expect(getJstHour(date)).toBe(hour);
+        expect(getServiceLevel(date)).toBe(expected);
+    });
+
+    test('treats an unusable clock as out of service instead of claiming to be open', () => {
+        expect(getServiceLevel(new Date('nonsense'))).toBe(SERVICE_LEVELS.closed);
+    });
+});

--- a/website/src/components/station_header.jsx
+++ b/website/src/components/station_header.jsx
@@ -1,29 +1,34 @@
 import { useEffect, useState } from 'react';
+import { formatJstTime, getServiceLevel } from '../utils/serviceStatus';
 
 // Slim wayfinding bar pinned to the top of every page — like the sign above a
-// platform: line roundel + network name on the left, a live Tokyo clock and an
-// in-service indicator on the right.
-function useTokyoClock() {
+// platform: line roundel + network name on the left, a live Tokyo clock and a
+// service indicator on the right. Both right-hand readouts are pinned to JST
+// regardless of where the viewer is, and the badge follows the Tokyo timetable.
+
+// Signal colours per service level: green go, amber off-peak, red late, and a
+// dead grey dot (no pulse) once the line is shut for the night.
+const LEVEL_STYLES = {
+    full: { text: 'text-neon', dot: 'bg-neon animate-pulse' },
+    reduced: { text: 'text-glow', dot: 'bg-glow animate-pulse' },
+    last: { text: 'text-alert', dot: 'bg-alert animate-pulse' },
+    closed: { text: 'text-content-accent', dot: 'bg-content-accent' },
+};
+
+function useTokyoNow() {
     const [now, setNow] = useState(() => new Date());
     useEffect(() => {
         const id = setInterval(() => setNow(new Date()), 1000);
         return () => clearInterval(id);
     }, []);
-    try {
-        return new Intl.DateTimeFormat('en-GB', {
-            timeZone: 'Asia/Tokyo',
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-            hour12: false,
-        }).format(now);
-    } catch {
-        return '--:--:--';
-    }
+    return now;
 }
 
 export default function StationHeader() {
-    const time = useTokyoClock();
+    const now = useTokyoNow();
+    const time = formatJstTime(now);
+    const level = getServiceLevel(now);
+    const styles = LEVEL_STYLES[level.key] ?? LEVEL_STYLES.full;
     return (
         <header
             id="station-header"
@@ -44,13 +49,18 @@ export default function StationHeader() {
                 <div className="flex items-center gap-4">
                     <span
                         className="tabular font-mono text-xs font-medium text-content-subtitle"
-                        aria-label={`Tokyo time ${time}`}
+                        aria-label={`Tokyo time (JST) ${time}`}
                     >
                         <span className="text-content-accent">JST</span> {time}
                     </span>
-                    <span className="flex items-center gap-1.5 font-mono text-[0.6rem] font-semibold uppercase tracking-[0.14em] text-neon max-sm:hidden">
-                        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neon" />
-                        In Service
+                    <span
+                        role="status"
+                        title={level.detail}
+                        aria-label={level.detail}
+                        className={`flex items-center gap-1.5 font-mono text-[0.6rem] font-semibold uppercase tracking-[0.14em] max-sm:hidden ${styles.text}`}
+                    >
+                        <span className={`h-1.5 w-1.5 rounded-full ${styles.dot}`} />
+                        {level.label}
                     </span>
                 </div>
             </div>

--- a/website/src/utils/serviceStatus.js
+++ b/website/src/utils/serviceStatus.js
@@ -1,0 +1,73 @@
+// The top bar reports Tokyo time and nothing else — a visitor in London sees the
+// same clock and the same service badge as a visitor in Osaka. Both are derived
+// from the JST wall clock here so they can never disagree.
+//
+// Japan has had no daylight saving since 1951, so JST is a flat UTC+09:00. That
+// makes plain offset arithmetic exact and keeps the header off `Intl` timezone
+// data entirely (no engine quirks, no `24:00:00` at midnight, trivially
+// testable).
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+export const JST_TIME_PLACEHOLDER = '--:--:--';
+
+const pad = (value) => String(value).padStart(2, '0');
+
+// Tokyo wall-clock parts for an instant, or null if handed an invalid Date.
+function jstParts(date) {
+    const time = date instanceof Date ? date.getTime() : Number.NaN;
+    if (Number.isNaN(time)) return null;
+    const shifted = new Date(time + JST_OFFSET_MS);
+    return {
+        hour: shifted.getUTCHours(),
+        minute: shifted.getUTCMinutes(),
+        second: shifted.getUTCSeconds(),
+    };
+}
+
+// Tokyo's hour as 0–23, or null for an invalid Date.
+export function getJstHour(date = new Date()) {
+    return jstParts(date)?.hour ?? null;
+}
+
+export function formatJstTime(date = new Date()) {
+    const parts = jstParts(date);
+    if (!parts) return JST_TIME_PLACEHOLDER;
+    return `${pad(parts.hour)}:${pad(parts.minute)}:${pad(parts.second)}`;
+}
+
+// Service bands read as a rail timetable: full daytime service, reduced service
+// on the shoulders either side of it, last trains late on, then the overnight
+// shutdown. `key` drives the badge styling in the header.
+export const SERVICE_LEVELS = {
+    full: {
+        key: 'full',
+        label: 'In Service',
+        detail: 'In service — full service 09:00–18:00 JST',
+    },
+    reduced: {
+        key: 'reduced',
+        label: 'Reduced Service',
+        detail: 'Reduced service — off-peak hours in Tokyo',
+    },
+    last: {
+        key: 'last',
+        label: 'Last Train',
+        detail: 'Last train — service winding down for the night in Tokyo',
+    },
+    closed: {
+        key: 'closed',
+        label: 'Out of Service',
+        detail: 'Out of service — overnight shutdown, 00:00–06:00 JST',
+    },
+};
+
+export function getServiceLevel(date = new Date()) {
+    const hour = getJstHour(date);
+    if (hour === null) return SERVICE_LEVELS.closed;
+    if (hour < 6) return SERVICE_LEVELS.closed; // 00:00–05:59
+    if (hour < 9) return SERVICE_LEVELS.reduced; // 06:00–08:59
+    if (hour < 18) return SERVICE_LEVELS.full; // 09:00–17:59
+    if (hour < 22) return SERVICE_LEVELS.reduced; // 18:00–21:59
+    return SERVICE_LEVELS.last; // 22:00–23:59
+}


### PR DESCRIPTION
## Summary
Refactored the station header to display accurate Tokyo time (JST) and dynamic service status badges that reflect the Tokyo timetable, regardless of the viewer's timezone.

## Key Changes
- **New utility module** (`serviceStatus.js`): Implements JST time conversion and service level logic
  - `formatJstTime()`: Converts UTC instants to Tokyo wall-clock time (UTC+9, no DST)
  - `getJstHour()`: Extracts the hour component in JST
  - `getServiceLevel()`: Maps JST hours to service bands (full/reduced/last train/closed)
  - Service levels defined with styling keys and user-facing labels

- **Updated StationHeader component**:
  - Replaced `Intl.DateTimeFormat` with direct UTC offset arithmetic for timezone-independent time display
  - Integrated dynamic service status badge that changes color and label based on Tokyo's timetable
  - Badge styling now reflects service level: green (full), amber (reduced), red (last train), grey (closed)
  - Removed hardcoded "In Service" text in favor of data-driven labels
  - Added proper ARIA labels and status role for accessibility

- **Comprehensive test coverage**:
  - `serviceStatus.test.js`: Unit tests for JST conversion and service band logic
  - `StationHeader.test.js`: Integration tests verifying time display, badge updates, and timezone independence

## Implementation Details
- Uses plain offset arithmetic (9 hours × 60 × 60 × 1000 ms) instead of timezone libraries to avoid engine quirks and DST complications
- Japan has had no daylight saving since 1951, making JST a flat UTC+9:00 offset
- Service bands follow a rail timetable pattern: full service 09:00–18:00, reduced shoulders, last trains 22:00–23:59, overnight shutdown 00:00–06:00
- Clock updates once per second via `setInterval`
- Badge stops pulsing animation when service is closed (out of service)

https://claude.ai/code/session_01FbH2LVZ6m2jALFo7YEXn4T