### PR TITLE
Add BrandIcon component with monogram fallback for missing icons

### DIFF
--- a/website/docs/ui-ux-review-2026-07.md
+++ b/website/docs/ui-ux-review-2026-07.md
@@ -169,6 +169,31 @@ list, now a single `.ticket-button`).
 "Japan Immigration Statistics Das…" had no way to reveal the rest. Added `title`
 attributes to the destination and operator.
 
+### 16. Skills toolbox had blank and mismatched icons — **fixed**
+
+Two entries pointed at Iconify names that do not exist in any of the 236 published
+sets, so they rendered as empty space: `simple-icons:crowdstrike` and
+`simple-icons:zscaler`. Simple Icons removes marks when a vendor's trademark policy
+requires it, and both were dropped after the names were written here — a silent
+break, because Iconify resolves at runtime and a miss renders nothing.
+
+Three more entries had a *valid* icon that was not the brand: `ph:shield-check-fill`
+for Qualys, `ph:devices-fill` for Kandji, `ph:robot-fill` for LiteLLM. Those read as
+category symbols in a row of brand marks, and they put a third icon language
+(Phosphor duotone) next to the full-colour `skill-icons` tiles and the flat
+`simple-icons` silhouettes.
+
+Iconify stays the primary source. Two of the five turned out to have real marks
+that were simply never found — `simple-icons:qualys` and `selfhst:litellm`. The
+remaining three are published nowhere, so they now resolve to a monogram plate:
+a signage tile in the same footprint as the icon it stands in for (`BrandIcon` in
+`components/ui/brand_icon.jsx`). It reads as a deliberate "no mark published"
+state rather than a wrong one, and redrawing the logos locally is exactly what
+the vendors' trademark policies got them pulled from Simple Icons for.
+
+The plate is driven by a runtime resolve rather than a hardcoded list, so it also
+covers the next mark that gets pulled from a set — and the CDN case below.
+
 ---
 
 ## Recorded, not changed
@@ -188,7 +213,10 @@ These are judgement calls or larger pieces of work; flagging rather than acting.
   every social link, nav icon and technology chip renders as an empty tile — which
   is exactly what happened in this review environment. Predates the redesign, but
   the redesign leans on icons more heavily. Bundling the ~30 icons actually used
-  would make the UI self-contained.
+  would make the UI self-contained. *Partly mitigated by #16*: the skills toolbox
+  now degrades to a readable monogram board instead of blank tiles when the API is
+  unreachable. Social links, nav and the chip lists still go blank — extending
+  `BrandIcon` to them, or bundling, is the remaining work.
 - **The desktop content column is 672px inside a 1152px container.** Fine for
   prose, tight for the Skills page, where the contribution heatmap and radar chart
   both have to compress into it. Consider letting `/skills` break out wider.
@@ -218,8 +246,10 @@ These are judgement calls or larger pieces of work; flagging rather than acting.
 
 ## Verification
 
-- `vitest run` — 17 files, 41 tests passing (4 snapshots updated, 7 new tests for
-  the date helpers).
+- `vitest run` — 18 files, 56 tests passing (7 snapshots updated, 7 new tests for
+  the date helpers, 13 for `BrandIcon`).
+- Every `logo` / `flag` / `icon` name in `assets/json` checked against all 236
+  published Iconify sets — all resolve.
 - `tsc --noEmit` — clean.
 - `axe-core` — zero violations across all 8 routes at 1280px and 390px.
 - Rendered sweep at 1440 / 820 / 390 / 320px — no horizontal overflow, no clipped

--- a/website/src/__tests__/BrandIcon.test.js
+++ b/website/src/__tests__/BrandIcon.test.js
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrandIcon, monogramFor } from '../components/ui/brand_icon';
+
+const { iconLoaded, loadIcon } = vi.hoisted(() => ({
+    iconLoaded: vi.fn(() => false),
+    loadIcon: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock('@iconify-icon/react', () => ({
+    Icon: ({ icon, width, height, className }) => (
+        <span data-testid='iconify' data-icon={icon} data-width={width} data-height={height} className={className} />
+    ),
+    iconLoaded,
+    loadIcon,
+}));
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    iconLoaded.mockReturnValue(false);
+    loadIcon.mockResolvedValue({});
+});
+
+describe('monogramFor', () => {
+    it.each([
+        ['CrowdStrike Falcon', 'CF'],
+        ['Zscaler', 'ZS'],
+        ['Kandji', 'KA'],
+        ['OpenTofu', 'OT'],
+        ['Node.js', 'NJ'],
+        // Trailing capitals are a suffix, not a word boundary.
+        ['macOS', 'MA'],
+        ['tailwindCSS', 'TA'],
+        ['', '??'],
+        [null, '??'],
+    ])('derives %s → %s', (name, expected) => {
+        expect(monogramFor(name)).toBe(expected);
+    });
+});
+
+describe('BrandIcon', () => {
+    it('renders the Iconify icon when the name resolves', async () => {
+        render(<BrandIcon icon='simple-icons:qualys' name='Qualys' size='1.5em' />);
+        await waitFor(() => expect(screen.getByTestId('iconify')).toHaveAttribute('data-icon', 'simple-icons:qualys'));
+        expect(screen.getByTestId('iconify')).toHaveAttribute('data-width', '1.5em');
+    });
+
+    it('falls back to a monogram when Iconify has no such icon', async () => {
+        loadIcon.mockRejectedValue(new Error('not found'));
+        render(<BrandIcon icon='simple-icons:zscaler' name='Zscaler' />);
+        await waitFor(() => expect(screen.getByText('ZS')).toBeInTheDocument());
+        expect(screen.queryByTestId('iconify')).not.toBeInTheDocument();
+    });
+
+    it('skips the lookup entirely when the data declares no logo', () => {
+        render(<BrandIcon icon={null} name='CrowdStrike Falcon' />);
+        expect(screen.getByText('CF')).toBeInTheDocument();
+        expect(loadIcon).not.toHaveBeenCalled();
+    });
+
+    it('prefers an explicit monogram override', () => {
+        render(<BrandIcon icon={null} name='CrowdStrike Falcon' monogram='CS' />);
+        expect(screen.getByText('CS')).toBeInTheDocument();
+    });
+
+    it('renders the fallback plate at the same footprint as the icon it replaces', () => {
+        const { container } = render(<BrandIcon icon={null} name='Kandji' size='1.5em' />);
+        const plate = container.firstChild;
+        expect(plate).toHaveStyle({ width: '1.5em', height: '1.5em' });
+        // Glyph scales with the plate rather than sitting at a fixed size.
+        expect(screen.getByText('KA')).toHaveStyle({ fontSize: '0.63em' });
+    });
+
+    it('does not render the icon before a slow lookup settles into failure', async () => {
+        let reject;
+        loadIcon.mockReturnValue(new Promise((_, r) => { reject = r; }));
+        render(<BrandIcon icon='simple-icons:zscaler' name='Zscaler' />);
+        // Optimistic: iconify-icon reserves the space itself, so no monogram flash.
+        expect(screen.getByTestId('iconify')).toBeInTheDocument();
+        reject(new Error('not found'));
+        await waitFor(() => expect(screen.getByText('ZS')).toBeInTheDocument());
+    });
+});

--- a/website/src/__tests__/__snapshots__/ExperienceList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/ExperienceList.test.js.snap
@@ -198,6 +198,7 @@ exports[`ExperienceList Component > matches snapshot 1`] = `
                   target="_blank"
                 >
                   <iconify-icon
+                    aria-hidden="true"
                     class="icon-box"
                     height="1.1em"
                     icon="ph:placeholder-fill"
@@ -212,6 +213,7 @@ exports[`ExperienceList Component > matches snapshot 1`] = `
                   target="_blank"
                 >
                   <iconify-icon
+                    aria-hidden="true"
                     class="icon-box"
                     height="1.1em"
                     icon="ph:placeholder-fill"
@@ -226,6 +228,7 @@ exports[`ExperienceList Component > matches snapshot 1`] = `
                   target="_blank"
                 >
                   <iconify-icon
+                    aria-hidden="true"
                     class="icon-box"
                     height="1.1em"
                     icon="ph:placeholder-fill"
@@ -240,6 +243,7 @@ exports[`ExperienceList Component > matches snapshot 1`] = `
                   target="_blank"
                 >
                   <iconify-icon
+                    aria-hidden="true"
                     class="icon-box"
                     height="1.1em"
                     icon="ph:placeholder-fill"

--- a/website/src/__tests__/__snapshots__/ProjectList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/ProjectList.test.js.snap
@@ -230,6 +230,7 @@ exports[`ProjectList Component > matches snapshot 1`] = `
                   target="_blank"
                 >
                   <iconify-icon
+                    aria-hidden="true"
                     class="icon-box"
                     height="1.1em"
                     icon="ph:generic-icon-1"
@@ -244,6 +245,7 @@ exports[`ProjectList Component > matches snapshot 1`] = `
                   target="_blank"
                 >
                   <iconify-icon
+                    aria-hidden="true"
                     class="icon-box"
                     height="1.1em"
                     icon="ph:generic-icon-2"
@@ -258,6 +260,7 @@ exports[`ProjectList Component > matches snapshot 1`] = `
                   target="_blank"
                 >
                   <iconify-icon
+                    aria-hidden="true"
                     class="icon-box"
                     height="1.1em"
                     icon="ph:generic-icon-3"

--- a/website/src/__tests__/__snapshots__/SkillButton.test.js.snap
+++ b/website/src/__tests__/__snapshots__/SkillButton.test.js.snap
@@ -12,6 +12,7 @@ exports[`SkillButton > matches snapshot with skills prop 1`] = `
       target="_blank"
     >
       <iconify-icon
+        aria-hidden="true"
         class="icon-box"
         height="1.1em"
         icon="skill1-icon"
@@ -26,6 +27,7 @@ exports[`SkillButton > matches snapshot with skills prop 1`] = `
       target="_blank"
     >
       <iconify-icon
+        aria-hidden="true"
         class="icon-box"
         height="1.1em"
         icon="skill2-icon"

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -81,21 +81,21 @@
       "name": "CrowdStrike Falcon",
       "category": "Security",
       "level": "55%",
-      "logo": "simple-icons:crowdstrike",
+      "logo": null,
       "website": "https://www.crowdstrike.com/"
     },
     {
       "name": "Zscaler",
       "category": "Security",
       "level": "50%",
-      "logo": "simple-icons:zscaler",
+      "logo": null,
       "website": "https://www.zscaler.com/"
     },
     {
       "name": "Qualys",
       "category": "Security",
       "level": "50%",
-      "logo": "ph:shield-check-fill",
+      "logo": "simple-icons:qualys",
       "website": "https://www.qualys.com/"
     },
     {
@@ -109,7 +109,7 @@
       "name": "Kandji",
       "category": "Endpoint (MDM)",
       "level": "60%",
-      "logo": "ph:devices-fill",
+      "logo": null,
       "website": "https://www.kandji.io/"
     },
     {
@@ -123,7 +123,7 @@
       "name": "LiteLLM",
       "category": "AI Gateway",
       "level": "50%",
-      "logo": "ph:robot-fill",
+      "logo": "selfhst:litellm",
       "website": "https://www.litellm.ai/"
     },
     {

--- a/website/src/components/skill_button.jsx
+++ b/website/src/components/skill_button.jsx
@@ -1,5 +1,5 @@
-import { Icon } from '@iconify-icon/react';
 import { useJsonData, LoadingSkeleton } from '../utils/useJsonData';
+import { BrandIcon } from './ui/brand_icon';
 
 const SkillButtonList = ({ skills }) => (
     <div className='flex flex-wrap max-sm:gap-1 sm:gap-2 md:gap-3'>
@@ -11,7 +11,13 @@ const SkillButtonList = ({ skills }) => (
                 target='_blank'
                 rel='noopener noreferrer'
             >
-                <Icon className='icon-box' icon={skill.logo} width='1.1em' height='1.1em' />
+                <BrandIcon
+                    className='icon-box'
+                    icon={skill.logo}
+                    name={skill.name}
+                    monogram={skill.monogram}
+                    size='1.1em'
+                />
                 {skill.name}
             </a>
         ))}

--- a/website/src/components/skill_highlight.jsx
+++ b/website/src/components/skill_highlight.jsx
@@ -1,5 +1,5 @@
-import { Icon } from '@iconify-icon/react';
 import { useJsonData, LoadingSkeleton } from '../utils/useJsonData';
+import { BrandIcon } from './ui/brand_icon';
 
 const pct = (level) => parseInt(String(level).replace('%', ''), 10) || 0;
 
@@ -31,7 +31,13 @@ const SkillHighlight = () => {
                         aria-label={`${skill.name} (opens in new tab)`}
                         className='group flex items-center gap-3 rounded border border-border bg-secondary-800/50 px-3 py-2 no-underline transition-colors hover:border-neon/40'
                     >
-                        <Icon icon={skill.logo} width='1.5em' height='1.5em' aria-hidden='true' />
+                        <BrandIcon
+                            icon={skill.logo}
+                            name={skill.name}
+                            monogram={skill.monogram}
+                            size='1.5em'
+                            className='shrink-0'
+                        />
                         <div className='flex min-w-0 flex-1 flex-col gap-1'>
                             <div className='flex items-baseline justify-between gap-2'>
                                 <span

--- a/website/src/components/ui/brand_icon.jsx
+++ b/website/src/components/ui/brand_icon.jsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { Icon, iconLoaded, loadIcon } from '@iconify-icon/react';
+import { cn } from '@/lib/utils';
+
+// ══ Brand icons ══════════════════════════════════════════════════════════════
+// Iconify stays the primary source: `logo` in the JSON is an Iconify name and is
+// rendered as-is. What Iconify can't promise is coverage. Simple Icons drops
+// marks when a vendor's trademark policy says to — CrowdStrike and Zscaler both
+// went that way — and smaller vendors (Kandji) were never in any of the 200+
+// sets to begin with.
+//
+// The previous workaround was to borrow an unrelated glyph from another set:
+// `ph:shield-check-fill` for Qualys, `ph:devices-fill` for Kandji. That reads as
+// a category symbol sitting in a row of brand marks, and it put a third icon
+// language (Phosphor duotone) next to the full-colour skill-icons tiles and the
+// flat simple-icons silhouettes.
+//
+// So: anything Iconify can't resolve falls back to a monogram plate — a signage
+// tile in exactly the footprint of the icon it stands in for. It reads as a
+// deliberate "no mark published" state rather than a wrong one. Because the
+// check is a runtime resolve rather than a hardcoded list, it also covers marks
+// that get pulled from a set later, and the case where api.iconify.design is
+// unreachable altogether — which used to leave every tile on the page blank.
+
+const WORD_SPLIT = /[\s./_-]+/;
+const NOISE = /[^\p{L}\p{N}+#]/gu;
+const UPPER = /\p{Lu}/gu;
+const LEADS_UPPER = /^\p{Lu}/u;
+const EM = /^\s*([\d.]+)\s*em\s*$/;
+
+// "CrowdStrike Falcon" → CF, "Zscaler" → ZS, "OpenTofu" → OT.
+export function monogramFor(name) {
+    const words = String(name ?? '')
+        .split(WORD_SPLIT)
+        .map((word) => word.replace(NOISE, ''))
+        .filter(Boolean);
+    if (words.length === 0) return '??';
+    if (words.length > 1) return (words[0][0] + words[1][0]).toUpperCase();
+    // A PascalCase word carries its own initials. Gated on the leading capital,
+    // because in `macOS` and `tailwindCSS` the inner capitals are a suffix, not
+    // a word boundary — those want the first two letters like anything else.
+    const word = words[0];
+    if (LEADS_UPPER.test(word)) {
+        const caps = word.match(UPPER);
+        if (caps && caps.length > 1) return (caps[0] + caps[1]).toUpperCase();
+    }
+    return word.slice(0, 2).toUpperCase();
+}
+
+// Sizes are passed in `em` so icons track the type scale of the row they sit in.
+const scaleEm = (size, factor, fallback) => {
+    const match = EM.exec(String(size));
+    return match ? `${Number((parseFloat(match[1]) * factor).toFixed(3))}em` : fallback;
+};
+
+// 'ok' — resolved; 'missing' — no such icon, or the API is unreachable.
+// 'pending' renders the icon optimistically: `iconify-icon` holds the space
+// itself while it loads, so betting on success avoids a monogram flash on every
+// cold load. Only a settled failure swaps in the plate.
+function useIconStatus(icon) {
+    const [status, setStatus] = useState(() => {
+        if (!icon) return 'missing';
+        return iconLoaded(icon) ? 'ok' : 'pending';
+    });
+
+    useEffect(() => {
+        if (!icon) {
+            setStatus('missing');
+            return undefined;
+        }
+        if (iconLoaded(icon)) {
+            setStatus('ok');
+            return undefined;
+        }
+        let active = true;
+        setStatus('pending');
+        Promise.resolve(loadIcon(icon)).then(
+            () => active && setStatus('ok'),
+            () => active && setStatus('missing'),
+        );
+        return () => {
+            active = false;
+        };
+    }, [icon]);
+
+    return status;
+}
+
+// Square plate carrying the monogram. Sized and radiused to sit in the icon slot
+// without disturbing the grid — the same crisp signage geometry as `.skill-block`.
+function MonogramPlate({ text, size, className }) {
+    return (
+        <span
+            aria-hidden='true'
+            className={cn(
+                'inline-grid shrink-0 place-items-center rounded-sm border border-border bg-secondary-700 text-content-accent',
+                className,
+            )}
+            style={{ width: size, height: size }}
+        >
+            <span
+                className='font-mono font-semibold leading-none tracking-tight'
+                style={{ fontSize: scaleEm(size, 0.42, '0.5em') }}
+            >
+                {text}
+            </span>
+        </span>
+    );
+}
+
+// `icon` may be null/absent — that is the explicit "no mark published" signal
+// from the data, and skips the network round-trip a known-dead name would cost.
+// `monogram` overrides the derived initials where the derivation reads badly.
+export function BrandIcon({ icon, name, monogram, size = '1.25em', className }) {
+    const status = useIconStatus(icon);
+
+    if (status === 'missing') {
+        return <MonogramPlate text={monogram || monogramFor(name)} size={size} className={className} />;
+    }
+    return <Icon className={className} icon={icon} width={size} height={size} aria-hidden='true' />;
+}
+
+export default BrandIcon;


### PR DESCRIPTION
## Summary
Replaces direct Iconify icon usage with a new `BrandIcon` component that gracefully handles missing or unavailable brand icons by falling back to a monogram plate. This fixes blank tiles in the Skills section when Iconify icons are unavailable (either due to trademark policy removals or API unreachability) and improves visual consistency.

## Key Changes

- **New `BrandIcon` component** (`components/ui/brand_icon.jsx`):
  - Wraps Iconify's `Icon` component with runtime icon resolution checking
  - Falls back to a `MonogramPlate` component when icons are missing
  - Includes `monogramFor()` utility to derive initials from brand names (e.g., "CrowdStrike Falcon" → "CF")
  - Supports explicit monogram overrides via the `monogram` prop
  - Handles three icon states: 'ok' (resolved), 'pending' (loading), 'missing' (fallback)

- **Updated skill data** (`assets/json/production/skill_data.json`):
  - Set `logo: null` for CrowdStrike Falcon and Zscaler (no published marks)
  - Set `logo: null` for Kandji (never published)
  - Corrected Qualys from `ph:shield-check-fill` to `simple-icons:qualys`
  - Corrected LiteLLM from `ph:robot-fill` to `selfhst:litellm`

- **Updated components** to use `BrandIcon`:
  - `skill_button.jsx`: Replaced `Icon` with `BrandIcon` for skill buttons
  - `skill_highlight.jsx`: Replaced `Icon` with `BrandIcon` for skill highlights

- **Comprehensive test coverage** (`__tests__/BrandIcon.test.js`):
  - 13 new tests covering monogram derivation, icon resolution, fallback behavior, and sizing
  - Tests verify optimistic rendering and graceful degradation

## Notable Implementation Details

- The monogram plate is sized and styled to match the icon footprint, maintaining grid alignment
- Icon resolution is optimistic: the component renders the icon while loading to avoid monogram flash on cold loads
- The fallback logic is runtime-based rather than hardcoded, so it automatically handles future icon removals from Iconify sets
- Provides resilience when the Iconify API is unreachable—skills display as readable monograms instead of blank tiles
- Monogram derivation handles PascalCase words (e.g., "OpenTofu" → "OT") and filters out special characters and noise

https://claude.ai/code/session_017AAyRQw2JiZdDBzGtnNVpu