### PR TITLE
Refactor skills visualization with dual charts and unified taxonomy

### DIFF
--- a/website/src/assets/css/index.css
+++ b/website/src/assets/css/index.css
@@ -139,6 +139,19 @@
     --chart-foreground-muted: #8ba7ac;
     --chart-label: #8ba7ac;
     --chart-grid: #17323c;
+
+    /* Ring ramp — a one-hue sequential scale in signal green, brightest step
+       first. The rings encode magnitude (how many tools sit in a category), so
+       lightness carries the value and hue stays out of it; the categorical
+       --chart-1..5 slots are for charts where colour means identity. Steps are
+       ~0.07 apart in OKLCH lightness, so each reads as its own step against the
+       dark surface, and the darkest still clears 3:1 against it. */
+    --chart-ramp-1: #6effad;
+    --chart-ramp-2: #0fec8e;
+    --chart-ramp-3: #1bd27e;
+    --chart-ramp-4: #10b86e;
+    --chart-ramp-5: #04a05e;
+    --chart-ramp-6: #0e8750;
 }
 
 /* Scrollbar-width compensation */

--- a/website/src/assets/json/development/skill_data.json
+++ b/website/src/assets/json/development/skill_data.json
@@ -2,28 +2,28 @@
   "core_skills": [
     {
       "name": "Placeholder",
-      "category": "Category",
+      "category": "Cloud",
       "level": "50%",
       "logo": "ph:placeholder-fill",
       "website": ""
     },
     {
       "name": "Placeholder",
-      "category": "Category",
+      "category": "Platform",
       "level": "25%",
       "logo": "ph:placeholder-fill",
       "website": "#"
     },
     {
       "name": "Placeholder",
-      "category": "Category",
+      "category": "Security",
       "level": "60%",
       "logo": "ph:placeholder-fill",
       "website": "#"
     },
     {
       "name": "Placeholder",
-      "category": "Category",
+      "category": "Development",
       "level": "50%",
       "logo": "ph:placeholder-fill",
       "website": "#"

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -23,21 +23,21 @@
     },
     {
       "name": "Terraform",
-      "category": "Automation",
+      "category": "Platform",
       "level": "75%",
       "logo": "skill-icons:terraform-light",
       "website": "https://www.terraform.io/"
     },
     {
       "name": "Docker",
-      "category": "Containerization",
+      "category": "Platform",
       "level": "45%",
       "logo": "skill-icons:docker",
       "website": "https://www.docker.com/"
     },
     {
       "name": "Kubernetes",
-      "category": "Orchestration",
+      "category": "Platform",
       "level": "60%",
       "logo": "skill-icons:kubernetes",
       "website": "https://kubernetes.io/"
@@ -51,28 +51,28 @@
     },
     {
       "name": "Go",
-      "category": "Programming Language",
+      "category": "Development",
       "level": "55%",
       "logo": "skill-icons:golang",
       "website": "https://go.dev/"
     },
     {
       "name": "OpenTofu",
-      "category": "Automation",
+      "category": "Platform",
       "level": "55%",
       "logo": "simple-icons:opentofu",
       "website": "https://opentofu.org/"
     },
     {
       "name": "GitHub Actions",
-      "category": "CI/CD",
+      "category": "Platform",
       "level": "70%",
       "logo": "simple-icons:githubactions",
       "website": "https://github.com/features/actions"
     },
     {
       "name": "Helm",
-      "category": "Orchestration",
+      "category": "Platform",
       "level": "45%",
       "logo": "simple-icons:helm",
       "website": "https://helm.sh/"
@@ -100,168 +100,168 @@
     },
     {
       "name": "Tailscale",
-      "category": "Networking",
+      "category": "Security",
       "level": "55%",
       "logo": "simple-icons:tailscale",
       "website": "https://tailscale.com/"
     },
     {
       "name": "Kandji",
-      "category": "Endpoint (MDM)",
+      "category": "Security",
       "level": "60%",
       "logo": "ph:devices-fill",
       "website": "https://www.kandji.io/"
     },
     {
       "name": "Grafana",
-      "category": "Observability",
+      "category": "Platform",
       "level": "50%",
       "logo": "simple-icons:grafana",
       "website": "https://grafana.com/"
     },
     {
       "name": "LiteLLM",
-      "category": "AI Gateway",
+      "category": "Platform",
       "level": "50%",
       "logo": "ph:robot-fill",
       "website": "https://www.litellm.ai/"
     },
     {
       "name": "Slack",
-      "category": "Collaboration",
+      "category": "Workplace",
       "level": "75%",
       "logo": "simple-icons:slack",
       "website": "https://slack.com/"
     },
     {
       "name": "Atlassian",
-      "category": "Collaboration",
+      "category": "Workplace",
       "level": "75%",
       "logo": "simple-icons:atlassian",
       "website": "https://www.atlassian.com/"
     },
     {
       "name": "Unreal Engine",
-      "category": "Game Development",
+      "category": "Creative",
       "level": "60%",
       "logo": "skill-icons:unrealengine",
       "website": "https://www.unrealengine.com/"
     },
     {
       "name": "Github",
-      "category": "Source Control",
+      "category": "Platform",
       "level": "65%",
       "logo": "skill-icons:github-light",
       "website": "https://github.com/"
     },
     {
       "name": "Perforce",
-      "category": "Source Control",
+      "category": "Platform",
       "level": "50%",
       "logo": "simple-icons:perforce",
       "website": "https://www.perforce.com/"
     },
     {
       "name": "C++",
-      "category": "Programming Language",
+      "category": "Development",
       "level": "30%",
       "logo": "skill-icons:cpp",
       "website": "https://cplusplus.com/"
     },
     {
       "name": "Python",
-      "category": "Scripting Language",
+      "category": "Development",
       "level": "45%",
       "logo": "skill-icons:python-light",
       "website": "https://www.python.org"
     },
     {
       "name": "BASh",
-      "category": "Command Language",
+      "category": "Development",
       "level": "70%",
       "logo": "skill-icons:bash-light",
       "website": "https://www.gnu.org/software/bash/"
     },
     {
       "name": "JavaScript",
-      "category": "Scripting Language",
+      "category": "Development",
       "level": "35%",
       "logo": "skill-icons:javascript",
       "website": "https://developer.oracle.com/languages/javascript.html"
     },
     {
       "name": "TypeScript",
-      "category": "Scripting Language",
+      "category": "Development",
       "level": "30%",
       "logo": "skill-icons:typescript",
       "website": "https://www.typescriptlang.org"
     },
     {
       "name": "Node.js",
-      "category": "Software",
+      "category": "Development",
       "level": "30%",
       "logo": "skill-icons:nodejs-light",
       "website": "https://nodejs.org"
     },
     {
       "name": "Next.js",
-      "category": "Framework",
+      "category": "Development",
       "level": "35%",
       "logo": "skill-icons:nextjs-light",
       "website": "https://nextjs.org/"
     },
     {
       "name": "React",
-      "category": "Library",
+      "category": "Development",
       "level": "45%",
       "logo": "skill-icons:react-dark",
       "website": "https://react.dev/"
     },
     {
       "name": "tailwindCSS",
-      "category": "Framework",
+      "category": "Development",
       "level": "50%",
       "logo": "skill-icons:tailwindcss-dark",
       "website": "https://tailwindcss.com"
     },
     {
       "name": "SideFX Houdini",
-      "category": "Software",
+      "category": "Creative",
       "level": "30%",
       "logo": "simple-icons:houdini",
       "website": "https://www.sidefx.com/"
     },
     {
       "name": "Blender",
-      "category": "Software",
+      "category": "Creative",
       "level": "55%",
       "logo": "skill-icons:blender-dark",
       "website": "https://www.blender.org/"
     },
     {
       "name": "Creative Cloud",
-      "category": "Software",
+      "category": "Creative",
       "level": "80%",
       "logo": "simple-icons:adobecreativecloud",
       "website": "https://www.adobe.com/creativecloud.html"
     },
     {
       "name": "Windows",
-      "category": "Operating System",
+      "category": "Workplace",
       "level": "100%",
       "logo": "skill-icons:windows-light",
       "website": "https://www.microsoft.com/en-us/windows"
     },
     {
       "name": "Kali Linux",
-      "category": "Operating System",
+      "category": "Security",
       "level": "40%",
       "logo": "skill-icons:kali-light",
       "website": "https://www.kali.org/"
     },
     {
       "name": "macOS",
-      "category": "Operating System",
+      "category": "Workplace",
       "level": "70%",
       "logo": "skill-icons:apple-light",
       "website": "https://www.apple.com"

--- a/website/src/components/charts/radar-grid.tsx
+++ b/website/src/components/charts/radar-grid.tsx
@@ -107,10 +107,17 @@ export function RadarGrid({
                 : undefined
             }
           >
+            {/* The scale runs up the inside of the plot, so every tick sits on
+                top of whatever the series have drawn there. Knock the label out
+                of the background first — otherwise a filled area swallows it. */}
             <text
               dominantBaseline="middle"
               fill={radarCssVars.foregroundMuted}
               fontSize={9}
+              paintOrder="stroke"
+              stroke={radarCssVars.background}
+              strokeWidth={3}
+              strokeLinejoin="round"
               textAnchor="start"
               x={4}
               y={-((i + 1) * radius) / levels}

--- a/website/src/components/charts/ring-center.tsx
+++ b/website/src/components/charts/ring-center.tsx
@@ -17,12 +17,6 @@ import { useRingHover, useRingStable } from "./ring-context";
 export interface RingCenterProps {
   /** Label shown below the value. Default: "Total" when not hovering */
   defaultLabel?: string;
-  /**
-   * Value shown when not hovering. Default: the sum of every ring's value —
-   * which only means something when the rings are parts of a whole. Rings
-   * carrying a rate or a score should pass their own headline number here.
-   */
-  defaultValue?: number;
   /** Format options for NumberFlow. Default: standard notation */
   formatOptions?: ChartStatFlowFormat;
   /** Custom render function for complete control over center content */
@@ -56,7 +50,6 @@ export interface RingCenterProps {
  */
 export function RingCenter({
   defaultLabel = "Total",
-  defaultValue,
   formatOptions = defaultChartStatFlowFormat,
   children,
   className = "",
@@ -69,9 +62,7 @@ export function RingCenter({
   const { hoveredIndex } = useRingHover();
 
   const hoveredData = hoveredIndex === null ? null : data[hoveredIndex];
-  const displayValue = hoveredData
-    ? hoveredData.value
-    : (defaultValue ?? totalValue);
+  const displayValue = hoveredData ? hoveredData.value : totalValue;
   const displayLabel = hoveredData ? hoveredData.label : defaultLabel;
 
   // Calculate center area size based on scaled baseInnerRadius

--- a/website/src/components/charts/ring-center.tsx
+++ b/website/src/components/charts/ring-center.tsx
@@ -17,6 +17,12 @@ import { useRingHover, useRingStable } from "./ring-context";
 export interface RingCenterProps {
   /** Label shown below the value. Default: "Total" when not hovering */
   defaultLabel?: string;
+  /**
+   * Value shown when not hovering. Default: the sum of every ring's value —
+   * which only means something when the rings are parts of a whole. Rings
+   * carrying a rate or a score should pass their own headline number here.
+   */
+  defaultValue?: number;
   /** Format options for NumberFlow. Default: standard notation */
   formatOptions?: ChartStatFlowFormat;
   /** Custom render function for complete control over center content */
@@ -50,6 +56,7 @@ export interface RingCenterProps {
  */
 export function RingCenter({
   defaultLabel = "Total",
+  defaultValue,
   formatOptions = defaultChartStatFlowFormat,
   children,
   className = "",
@@ -62,7 +69,9 @@ export function RingCenter({
   const { hoveredIndex } = useRingHover();
 
   const hoveredData = hoveredIndex === null ? null : data[hoveredIndex];
-  const displayValue = hoveredData ? hoveredData.value : totalValue;
+  const displayValue = hoveredData
+    ? hoveredData.value
+    : (defaultValue ?? totalValue);
   const displayLabel = hoveredData ? hoveredData.label : defaultLabel;
 
   // Calculate center area size based on scaled baseInnerRadius

--- a/website/src/components/skill_highlight.jsx
+++ b/website/src/components/skill_highlight.jsx
@@ -1,7 +1,6 @@
 import { Icon } from '@iconify-icon/react';
 import { useJsonData, LoadingSkeleton } from '../utils/useJsonData';
-
-const pct = (level) => parseInt(String(level).replace('%', ''), 10) || 0;
+import { groupSkills, pct, rampColor } from '../utils/skillTaxonomy';
 
 // The bar is a proficiency reading, so its colour has to mean proficiency.
 // Cycling the line-badge palette instead painted Terraform in `--color-alert`
@@ -13,54 +12,95 @@ const barColor = (level) => {
     return 'var(--color-secondary-400)';
 };
 
+function SkillCard({ skill }) {
+    const level = pct(skill.level);
+    return (
+        <a
+            href={skill.website}
+            target='_blank'
+            rel='noopener noreferrer'
+            aria-label={`${skill.name} (opens in new tab)`}
+            className='group flex items-center gap-3 rounded border border-border bg-secondary-800/50 px-3 py-2 no-underline transition-colors hover:border-neon/40'
+        >
+            <Icon icon={skill.logo} width='1.5em' height='1.5em' aria-hidden='true' />
+            <div className='flex min-w-0 flex-1 flex-col gap-1'>
+                <div className='flex items-baseline justify-between gap-2'>
+                    <span
+                        className='truncate text-sm font-semibold text-content-subtitle group-hover:text-content-title'
+                        title={skill.name}
+                    >
+                        {skill.name}
+                    </span>
+                    <span className='tabular shrink-0 font-mono text-[0.6rem] uppercase tracking-wide text-content-accent'>
+                        {skill.level}
+                    </span>
+                </div>
+                <div
+                    className='h-1.5 w-full overflow-hidden rounded-full bg-background'
+                    role='progressbar'
+                    aria-valuenow={level}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label={`${skill.name} proficiency`}
+                >
+                    <div
+                        className='h-full rounded-full transition-all'
+                        style={{ width: `${level}%`, background: barColor(level) }}
+                    />
+                </div>
+            </div>
+        </a>
+    );
+}
+
 const SkillHighlight = () => {
     const { data, loading, error } = useJsonData('skill_data.json');
     if (loading) return <LoadingSkeleton />;
     if (error || !data) return null;
-    const skills = [...data.core_skills].sort((a, b) => pct(b.level) - pct(a.level));
+
+    // One drawer per category, biggest first — the same order, and the same
+    // ramp colour, as the rings above. All shut on arrival: the list runs to
+    // dozens of tools, and a wall of them is nobody's idea of a summary.
+    const groups = groupSkills(data.core_skills ?? []);
+
     return (
-        <div className='grid grid-cols-1 gap-2.5 sm:grid-cols-2'>
-            {skills.map((skill) => {
-                const level = pct(skill.level);
-                return (
-                    <a
-                        key={skill.name}
-                        href={skill.website}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                        aria-label={`${skill.name} (opens in new tab)`}
-                        className='group flex items-center gap-3 rounded border border-border bg-secondary-800/50 px-3 py-2 no-underline transition-colors hover:border-neon/40'
-                    >
-                        <Icon icon={skill.logo} width='1.5em' height='1.5em' aria-hidden='true' />
-                        <div className='flex min-w-0 flex-1 flex-col gap-1'>
-                            <div className='flex items-baseline justify-between gap-2'>
-                                <span
-                                    className='truncate text-sm font-semibold text-content-subtitle group-hover:text-content-title'
-                                    title={skill.name}
-                                >
-                                    {skill.name}
-                                </span>
-                                <span className='tabular shrink-0 font-mono text-[0.6rem] uppercase tracking-wide text-content-accent'>
-                                    {skill.category}
-                                </span>
-                            </div>
-                            <div
-                                className='h-1.5 w-full overflow-hidden rounded-full bg-background'
-                                role='progressbar'
-                                aria-valuenow={level}
-                                aria-valuemin={0}
-                                aria-valuemax={100}
-                                aria-label={`${skill.name} proficiency`}
-                            >
-                                <div
-                                    className='h-full rounded-full transition-all'
-                                    style={{ width: `${level}%`, background: barColor(level) }}
-                                />
-                            </div>
-                        </div>
-                    </a>
-                );
-            })}
+        <div className='flex flex-col gap-2'>
+            {groups.map((group, index) => (
+                <details
+                    key={group.name}
+                    name='rolling-stock'
+                    className='group overflow-hidden rounded border border-border bg-secondary-800/40 [&_summary::-webkit-details-marker]:hidden'
+                >
+                    <summary className='grid cursor-pointer list-none items-center gap-3 px-3 py-2.5 transition-colors hover:bg-secondary-800/80 [grid-template-columns:auto_1fr_auto]'>
+                        <span
+                            aria-hidden='true'
+                            className='inline-block h-2.5 w-2.5 shrink-0 rounded-full'
+                            style={{ backgroundColor: rampColor(index) }}
+                        />
+                        <span className='flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5'>
+                            <span className='font-heading text-[0.95rem] font-bold uppercase leading-tight tracking-wide text-content-title sm:text-base'>
+                                {group.name}
+                            </span>
+                            <span className='tabular font-mono text-[0.58rem] uppercase tracking-wider text-content-accent sm:text-[0.62rem]'>
+                                {group.count} {group.count === 1 ? 'tool' : 'tools'} · avg {group.avg}%
+                            </span>
+                        </span>
+                        <span
+                            aria-hidden='true'
+                            className='text-content-accent transition-transform group-open:rotate-90'
+                        >
+                            <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='3'>
+                                <path d='M9 6l6 6-6 6' />
+                            </svg>
+                        </span>
+                    </summary>
+                    <div className='grid grid-cols-1 gap-2.5 border-t border-border/60 bg-background/40 px-3 pb-3 pt-3 sm:grid-cols-2'>
+                        {group.skills.map((skill) => (
+                            <SkillCard key={skill.name} skill={skill} />
+                        ))}
+                    </div>
+                </details>
+            ))}
         </div>
     );
 };

--- a/website/src/components/skills_charts.tsx
+++ b/website/src/components/skills_charts.tsx
@@ -17,7 +17,7 @@ type CoreSkill = { name: string; category: string; level: string };
  * this page — the badges on each tool, the radar, the rings — reads that one
  * field. The old data had twenty categories, half of them a single tool deep
  * ("AI Gateway", "Endpoint (MDM)", "Game Development"), which is why the radar
- * needed a private lookup table and why counting anything was meaningless.
+ * needed a private lookup table and why scoring anything was meaningless.
  *
  *   Cloud        the public clouds themselves
  *   Platform     what runs on them — IaC, CI/CD, containers, observability, repos
@@ -27,18 +27,17 @@ type CoreSkill = { name: string; category: string; level: string };
  *   Creative     the pre-engineering craft — real-time, 3D, VFX, design
  *
  * A tool whose category is off-list lands in `Other` rather than disappearing,
- * so the number in the middle of the rings always equals the number of tools in
- * the list below them.
+ * so no part of the toolbox is left out of the scoring.
  */
 const CATEGORIES = ['Cloud', 'Platform', 'Security', 'Development', 'Workplace', 'Creative'];
 const OTHER = 'Other';
 
-// Sequential ramp, brightest = biggest bucket. See --chart-ramp-* in index.css.
+// Sequential ramp, brightest = highest-scoring bucket. See --chart-ramp-* in index.css.
 const RAMP_STEPS = 6;
 
 const pct = (level: string) => parseInt(String(level).replace('%', ''), 10) || 0;
 
-type Bucket = { name: string; count: number; peak: number };
+type Bucket = { name: string; count: number; peak: number; avg: number };
 
 function bucketize(core: CoreSkill[]): Bucket[] {
     const known = new Set(CATEGORIES);
@@ -47,10 +46,12 @@ function bucketize(core: CoreSkill[]): Bucket[] {
             const levels = core
                 .filter((s) => (known.has(s.category) ? s.category === name : name === OTHER))
                 .map((s) => pct(s.level));
+            const sum = levels.reduce((a, b) => a + b, 0);
             return {
                 name,
                 count: levels.length,
                 peak: levels.reduce((max, v) => Math.max(max, v), 0),
+                avg: levels.length ? Math.round(sum / levels.length) : 0,
             };
         })
         .filter((b) => b.count > 0);
@@ -72,16 +73,18 @@ export default function SkillsCharts() {
     const metrics = buckets.map((b) => ({ key: b.name, label: b.name }));
     const radarData = [{ label: 'Peak proficiency', values }];
 
-    // Rings — how much of the toolbox each category accounts for. The widest
-    // category fills its ring, so the rest read as shares of it; the exact
-    // counts are in the legend and the centre carries the total.
-    const ranked = [...buckets].sort((a, b) => b.count - a.count || b.peak - a.peak);
-    const widest = ranked[0].count;
+    // Rings — the same categories scored on how deep they run rather than how
+    // high they reach: the mean proficiency of every tool in the bucket, out of
+    // 100. Read against the radar, the gap is the interesting part — a category
+    // can peak at 80 and still average 35 when it is one strong tool and two
+    // passing acquaintances.
+    const ranked = [...buckets].sort((a, b) => b.avg - a.avg || b.count - a.count);
+    const overallAvg = Math.round(core.reduce((sum, s) => sum + pct(s.level), 0) / core.length);
     const rings = ranked.map((b, i) => ({
         label: b.name,
-        value: b.count,
-        maxValue: widest,
-        peak: b.peak,
+        value: b.avg,
+        maxValue: 100,
+        count: b.count,
         color: `var(--chart-ramp-${Math.min(i + 1, RAMP_STEPS)})`,
     }));
 
@@ -99,9 +102,7 @@ export default function SkillsCharts() {
                     </RadarChart>
                     <figcaption className='flex flex-col items-center gap-1 font-mono text-xs uppercase tracking-wider text-content-accent'>
                         // peak proficiency by category
-                        <span className='sr-only'>
-                            {buckets.map((b) => `${b.name}: ${b.peak}%`).join(', ')}
-                        </span>
+                        <span className='sr-only'>{buckets.map((b) => `${b.name}: ${b.peak}%`).join(', ')}</span>
                     </figcaption>
                 </figure>
 
@@ -116,10 +117,10 @@ export default function SkillsCharts() {
                         {rings.map((r, i) => (
                             <Ring key={r.label} index={i} showGlow />
                         ))}
-                        <RingCenter defaultLabel='Tools' />
+                        <RingCenter defaultLabel='Avg' defaultValue={overallAvg} suffix='%' />
                     </RingChart>
                     <figcaption className='flex w-full flex-col items-center gap-2 font-mono text-xs uppercase tracking-wider text-content-accent'>
-                        // toolbox by category
+                        // average score by category
                         <ul className='m-0 flex w-full max-w-[300px] list-none flex-col gap-1 p-0 normal-case tracking-normal'>
                             {rings.map((r) => (
                                 <li key={r.label} className='flex items-baseline justify-between gap-3 text-[0.68rem]'>
@@ -132,7 +133,7 @@ export default function SkillsCharts() {
                                         {r.label}
                                     </span>
                                     <span className='tabular whitespace-nowrap'>
-                                        {r.value} · peak {r.peak}%
+                                        {r.value}% · {r.count} tools
                                     </span>
                                 </li>
                             ))}

--- a/website/src/components/skills_charts.tsx
+++ b/website/src/components/skills_charts.tsx
@@ -27,13 +27,24 @@ type CoreSkill = { name: string; category: string; level: string };
  *   Creative     the pre-engineering craft — real-time, 3D, VFX, design
  *
  * A tool whose category is off-list lands in `Other` rather than disappearing,
- * so no part of the toolbox is left out of the scoring.
+ * so the number in the middle of the rings always equals the number of tools in
+ * the list.
+ *
+ * The two charts split the work: the radar carries depth (both the ceiling and
+ * the average of a category, so the gap between them is visible), the rings
+ * carry breadth (how much of the toolbox sits in each). Neither repeats the
+ * other, and the table under the rings spells out all three numbers.
  */
 const CATEGORIES = ['Cloud', 'Platform', 'Security', 'Development', 'Workplace', 'Creative'];
 const OTHER = 'Other';
 
-// Sequential ramp, brightest = highest-scoring bucket. See --chart-ramp-* in index.css.
+// Sequential ramp, brightest = largest bucket. See --chart-ramp-* in index.css.
 const RAMP_STEPS = 6;
+
+// Peak is the outer envelope, average the solid core it sits on — amber reads as
+// headroom against the signal green the rest of the page uses for what is real.
+const PEAK_COLOR = 'var(--chart-2)';
+const AVG_COLOR = 'var(--chart-1)';
 
 const pct = (level: string) => parseInt(String(level).replace('%', ''), 10) || 0;
 
@@ -57,6 +68,22 @@ function bucketize(core: CoreSkill[]): Bucket[] {
         .filter((b) => b.count > 0);
 }
 
+function SeriesKey({ color, filled, children }: { color: string; filled: boolean; children: string }) {
+    return (
+        <span className='inline-flex items-center gap-1.5'>
+            <span
+                aria-hidden='true'
+                className='inline-block h-2.5 w-2.5 rounded-full'
+                style={{
+                    border: `2px solid ${color}`,
+                    backgroundColor: filled ? color : 'transparent',
+                }}
+            />
+            {children}
+        </span>
+    );
+}
+
 export default function SkillsCharts() {
     const { data } = useJsonData('skill_data.json') as {
         data: { core_skills?: CoreSkill[] } | null;
@@ -66,25 +93,33 @@ export default function SkillsCharts() {
 
     const buckets = bucketize(core);
 
-    // Radar — the ceiling of each category, axes kept in taxonomy order so the
-    // shape means the same thing from one visit to the next.
-    const values: Record<string, number> = {};
-    for (const bucket of buckets) values[bucket.name] = bucket.peak;
+    // Radar — two readings of the same six axes. Peak is what a category can
+    // reach, average is how deep it runs, and every category's average sits
+    // inside its peak, so the band between them is headroom: Cloud peaks at 80
+    // on AWS and averages 35 once Azure and GCP are counted.
+    const peaks: Record<string, number> = {};
+    const averages: Record<string, number> = {};
+    for (const bucket of buckets) {
+        peaks[bucket.name] = bucket.peak;
+        averages[bucket.name] = bucket.avg;
+    }
     const metrics = buckets.map((b) => ({ key: b.name, label: b.name }));
-    const radarData = [{ label: 'Peak proficiency', values }];
+    const radarData = [
+        { label: 'Peak', values: peaks, color: PEAK_COLOR },
+        { label: 'Average', values: averages, color: AVG_COLOR },
+    ];
 
-    // Rings — the same categories scored on how deep they run rather than how
-    // high they reach: the mean proficiency of every tool in the bucket, out of
-    // 100. Read against the radar, the gap is the interesting part — a category
-    // can peak at 80 and still average 35 when it is one strong tool and two
-    // passing acquaintances.
-    const ranked = [...buckets].sort((a, b) => b.avg - a.avg || b.count - a.count);
-    const overallAvg = Math.round(core.reduce((sum, s) => sum + pct(s.level), 0) / core.length);
+    // Rings — how much of the toolbox each category accounts for. The widest
+    // category fills its ring, so the rest read as shares of it; the exact
+    // counts are in the table and the centre carries the total.
+    const ranked = [...buckets].sort((a, b) => b.count - a.count || b.avg - a.avg);
+    const widest = ranked[0].count;
     const rings = ranked.map((b, i) => ({
         label: b.name,
-        value: b.avg,
-        maxValue: 100,
-        count: b.count,
+        value: b.count,
+        maxValue: widest,
+        avg: b.avg,
+        peak: b.peak,
         color: `var(--chart-ramp-${Math.min(i + 1, RAMP_STEPS)})`,
     }));
 
@@ -97,12 +132,20 @@ export default function SkillsCharts() {
                     <RadarChart data={radarData} metrics={metrics} className='mx-auto max-w-[380px]'>
                         <RadarGrid />
                         <RadarAxis />
-                        <RadarArea index={0} showGlow />
+                        <RadarArea index={0} showPoints={false} showGlow />
+                        <RadarArea index={1} showGlow />
                         <RadarLabels />
                     </RadarChart>
-                    <figcaption className='flex flex-col items-center gap-1 font-mono text-xs uppercase tracking-wider text-content-accent'>
-                        // peak proficiency by category
-                        <span className='sr-only'>{buckets.map((b) => `${b.name}: ${b.peak}%`).join(', ')}</span>
+                    <figcaption className='flex flex-col items-center gap-2 font-mono text-xs uppercase tracking-wider text-content-accent'>
+                        // proficiency by category
+                        <span className='flex flex-wrap justify-center gap-x-4 gap-y-1 text-[0.68rem] normal-case tracking-normal text-content-subtitle'>
+                            <SeriesKey color={PEAK_COLOR} filled={false}>
+                                peak
+                            </SeriesKey>
+                            <SeriesKey color={AVG_COLOR} filled>
+                                average
+                            </SeriesKey>
+                        </span>
                     </figcaption>
                 </figure>
 
@@ -117,27 +160,50 @@ export default function SkillsCharts() {
                         {rings.map((r, i) => (
                             <Ring key={r.label} index={i} showGlow />
                         ))}
-                        <RingCenter defaultLabel='Avg' defaultValue={overallAvg} suffix='%' />
+                        <RingCenter defaultLabel='Tools' />
                     </RingChart>
                     <figcaption className='flex w-full flex-col items-center gap-2 font-mono text-xs uppercase tracking-wider text-content-accent'>
-                        // average score by category
-                        <ul className='m-0 flex w-full max-w-[300px] list-none flex-col gap-1 p-0 normal-case tracking-normal'>
-                            {rings.map((r) => (
-                                <li key={r.label} className='flex items-baseline justify-between gap-3 text-[0.68rem]'>
-                                    <span className='flex items-center gap-1.5 text-content-subtitle'>
-                                        <span
-                                            aria-hidden='true'
-                                            className='inline-block h-2 w-2 shrink-0 rounded-full'
-                                            style={{ backgroundColor: r.color }}
-                                        />
-                                        {r.label}
-                                    </span>
-                                    <span className='tabular whitespace-nowrap'>
-                                        {r.value}% · {r.count} tools
-                                    </span>
-                                </li>
-                            ))}
-                        </ul>
+                        // toolbox by category
+                        <table className='w-full max-w-[320px] border-collapse text-[0.68rem] normal-case tracking-normal'>
+                            <caption className='sr-only'>
+                                Tools, average proficiency and peak proficiency in each category
+                            </caption>
+                            <thead>
+                                <tr className='text-content-date'>
+                                    <th scope='col' className='text-left font-normal'>
+                                        <span className='sr-only'>Category</span>
+                                    </th>
+                                    <th scope='col' className='pl-2 text-right font-normal'>
+                                        tools
+                                    </th>
+                                    <th scope='col' className='pl-3 text-right font-normal'>
+                                        avg
+                                    </th>
+                                    <th scope='col' className='pl-3 text-right font-normal'>
+                                        peak
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {rings.map((r) => (
+                                    <tr key={r.label}>
+                                        <th scope='row' className='py-px text-left font-normal text-content-subtitle'>
+                                            <span className='flex items-center gap-1.5'>
+                                                <span
+                                                    aria-hidden='true'
+                                                    className='inline-block h-2 w-2 shrink-0 rounded-full'
+                                                    style={{ backgroundColor: r.color }}
+                                                />
+                                                {r.label}
+                                            </span>
+                                        </th>
+                                        <td className='tabular py-px pl-2 text-right'>{r.value}</td>
+                                        <td className='tabular py-px pl-3 text-right'>{r.avg}%</td>
+                                        <td className='tabular py-px pl-3 text-right'>{r.peak}%</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
                     </figcaption>
                 </figure>
             </div>

--- a/website/src/components/skills_charts.tsx
+++ b/website/src/components/skills_charts.tsx
@@ -8,65 +8,23 @@ import { RingChart } from './charts/ring-chart';
 import { Ring } from './charts/ring';
 import { RingCenter } from './charts/ring-center';
 import GithubHeatmap from './github_heatmap';
+import { byTaxonomyOrder, groupSkills, rampColor } from '../utils/skillTaxonomy';
 
 type CoreSkill = { name: string; category: string; level: string };
 
 /**
- * One taxonomy, six buckets. Every tool in the Rolling Stock list carries
- * exactly one of these as its `category` in skill_data.json, and everything on
- * this page — the badges on each tool, the radar, the rings — reads that one
- * field. The old data had twenty categories, half of them a single tool deep
- * ("AI Gateway", "Endpoint (MDM)", "Game Development"), which is why the radar
- * needed a private lookup table and why scoring anything was meaningless.
- *
- *   Cloud        the public clouds themselves
- *   Platform     what runs on them — IaC, CI/CD, containers, observability, repos
- *   Security     identity, endpoint posture, network, vulnerability, offensive
- *   Development  languages and the web stack
- *   Workplace    the endpoints and the tools the company works in
- *   Creative     the pre-engineering craft — real-time, 3D, VFX, design
- *
- * A tool whose category is off-list lands in `Other` rather than disappearing,
- * so the number in the middle of the rings always equals the number of tools in
- * the list.
- *
- * The two charts split the work: the radar carries depth (both the ceiling and
- * the average of a category, so the gap between them is visible), the rings
- * carry breadth (how much of the toolbox sits in each). Neither repeats the
- * other, and the table under the rings spells out all three numbers.
+ * Both charts read the categories the Rolling Stock list is grouped by — see
+ * utils/skillTaxonomy for the taxonomy itself — and split the work between
+ * them. The radar carries depth: a category's ceiling and its average, so the
+ * gap between the two is visible. The rings carry breadth: how much of the
+ * toolbox each category accounts for. Neither repeats the other, and the table
+ * under the rings spells out all three numbers.
  */
-const CATEGORIES = ['Cloud', 'Platform', 'Security', 'Development', 'Workplace', 'Creative'];
-const OTHER = 'Other';
-
-// Sequential ramp, brightest = largest bucket. See --chart-ramp-* in index.css.
-const RAMP_STEPS = 6;
 
 // Peak is the outer envelope, average the solid core it sits on — amber reads as
 // headroom against the signal green the rest of the page uses for what is real.
 const PEAK_COLOR = 'var(--chart-2)';
 const AVG_COLOR = 'var(--chart-1)';
-
-const pct = (level: string) => parseInt(String(level).replace('%', ''), 10) || 0;
-
-type Bucket = { name: string; count: number; peak: number; avg: number };
-
-function bucketize(core: CoreSkill[]): Bucket[] {
-    const known = new Set(CATEGORIES);
-    return [...CATEGORIES, OTHER]
-        .map((name) => {
-            const levels = core
-                .filter((s) => (known.has(s.category) ? s.category === name : name === OTHER))
-                .map((s) => pct(s.level));
-            const sum = levels.reduce((a, b) => a + b, 0);
-            return {
-                name,
-                count: levels.length,
-                peak: levels.reduce((max, v) => Math.max(max, v), 0),
-                avg: levels.length ? Math.round(sum / levels.length) : 0,
-            };
-        })
-        .filter((b) => b.count > 0);
-}
 
 function SeriesKey({ color, filled, children }: { color: string; filled: boolean; children: string }) {
     return (
@@ -91,19 +49,22 @@ export default function SkillsCharts() {
     const core: CoreSkill[] = data?.core_skills ?? [];
     if (core.length === 0) return null;
 
-    const buckets = bucketize(core);
+    // Grouped biggest-first, the same order the toolbox drawers use below.
+    const groups = groupSkills(core);
 
-    // Radar — two readings of the same six axes. Peak is what a category can
-    // reach, average is how deep it runs, and every category's average sits
-    // inside its peak, so the band between them is headroom: Cloud peaks at 80
-    // on AWS and averages 35 once Azure and GCP are counted.
+    // Radar — two readings of the same axes. Peak is what a category can reach,
+    // average is how deep it runs, and every category's average sits inside its
+    // peak, so the band between them is headroom: Cloud peaks at 80 on AWS and
+    // averages 35 once Azure and GCP are counted. Axes stay in taxonomy order so
+    // the shape means the same thing from one visit to the next.
+    const axes = [...groups].sort(byTaxonomyOrder);
     const peaks: Record<string, number> = {};
     const averages: Record<string, number> = {};
-    for (const bucket of buckets) {
-        peaks[bucket.name] = bucket.peak;
-        averages[bucket.name] = bucket.avg;
+    for (const group of axes) {
+        peaks[group.name] = group.peak;
+        averages[group.name] = group.avg;
     }
-    const metrics = buckets.map((b) => ({ key: b.name, label: b.name }));
+    const metrics = axes.map((g) => ({ key: g.name, label: g.name }));
     const radarData = [
         { label: 'Peak', values: peaks, color: PEAK_COLOR },
         { label: 'Average', values: averages, color: AVG_COLOR },
@@ -112,15 +73,14 @@ export default function SkillsCharts() {
     // Rings — how much of the toolbox each category accounts for. The widest
     // category fills its ring, so the rest read as shares of it; the exact
     // counts are in the table and the centre carries the total.
-    const ranked = [...buckets].sort((a, b) => b.count - a.count || b.avg - a.avg);
-    const widest = ranked[0].count;
-    const rings = ranked.map((b, i) => ({
-        label: b.name,
-        value: b.count,
+    const widest = groups[0].count;
+    const rings = groups.map((g, i) => ({
+        label: g.name,
+        value: g.count,
         maxValue: widest,
-        avg: b.avg,
-        peak: b.peak,
-        color: `var(--chart-ramp-${Math.min(i + 1, RAMP_STEPS)})`,
+        avg: g.avg,
+        peak: g.peak,
+        color: rampColor(i),
     }));
 
     return (

--- a/website/src/components/skills_charts.tsx
+++ b/website/src/components/skills_charts.tsx
@@ -4,28 +4,57 @@ import { RadarGrid } from './charts/radar-grid';
 import { RadarAxis } from './charts/radar-axis';
 import { RadarArea } from './charts/radar-area';
 import { RadarLabels } from './charts/radar-labels';
+import { RingChart } from './charts/ring-chart';
+import { Ring } from './charts/ring';
+import { RingCenter } from './charts/ring-center';
 import GithubHeatmap from './github_heatmap';
 
 type CoreSkill = { name: string; category: string; level: string };
 
-// Roll the many fine-grained categories up into the domains that matter for a
-// cloud/security engineer. A domain's score = the peak skill within it.
-const CATEGORY_TO_DOMAIN: Record<string, string> = {
-    Cloud: 'Cloud',
-    Automation: 'Automation',
-    Containerization: 'Containers',
-    Orchestration: 'Containers',
-    Security: 'Security',
-    'Operating System': 'Systems',
-    'Command Language': 'Scripting',
-    'Scripting Language': 'Scripting',
-    'Programming Language': 'Scripting',
-    Library: 'Web',
-    Framework: 'Web',
-};
-const DOMAINS = ['Cloud', 'Automation', 'Security', 'Containers', 'Scripting', 'Systems'];
+/**
+ * One taxonomy, six buckets. Every tool in the Rolling Stock list carries
+ * exactly one of these as its `category` in skill_data.json, and everything on
+ * this page — the badges on each tool, the radar, the rings — reads that one
+ * field. The old data had twenty categories, half of them a single tool deep
+ * ("AI Gateway", "Endpoint (MDM)", "Game Development"), which is why the radar
+ * needed a private lookup table and why counting anything was meaningless.
+ *
+ *   Cloud        the public clouds themselves
+ *   Platform     what runs on them — IaC, CI/CD, containers, observability, repos
+ *   Security     identity, endpoint posture, network, vulnerability, offensive
+ *   Development  languages and the web stack
+ *   Workplace    the endpoints and the tools the company works in
+ *   Creative     the pre-engineering craft — real-time, 3D, VFX, design
+ *
+ * A tool whose category is off-list lands in `Other` rather than disappearing,
+ * so the number in the middle of the rings always equals the number of tools in
+ * the list below them.
+ */
+const CATEGORIES = ['Cloud', 'Platform', 'Security', 'Development', 'Workplace', 'Creative'];
+const OTHER = 'Other';
+
+// Sequential ramp, brightest = biggest bucket. See --chart-ramp-* in index.css.
+const RAMP_STEPS = 6;
 
 const pct = (level: string) => parseInt(String(level).replace('%', ''), 10) || 0;
+
+type Bucket = { name: string; count: number; peak: number };
+
+function bucketize(core: CoreSkill[]): Bucket[] {
+    const known = new Set(CATEGORIES);
+    return [...CATEGORIES, OTHER]
+        .map((name) => {
+            const levels = core
+                .filter((s) => (known.has(s.category) ? s.category === name : name === OTHER))
+                .map((s) => pct(s.level));
+            return {
+                name,
+                count: levels.length,
+                peak: levels.reduce((max, v) => Math.max(max, v), 0),
+            };
+        })
+        .filter((b) => b.count > 0);
+}
 
 export default function SkillsCharts() {
     const { data } = useJsonData('skill_data.json') as {
@@ -34,32 +63,83 @@ export default function SkillsCharts() {
     const core: CoreSkill[] = data?.core_skills ?? [];
     if (core.length === 0) return null;
 
-    // radar: peak proficiency per domain
+    const buckets = bucketize(core);
+
+    // Radar — the ceiling of each category, axes kept in taxonomy order so the
+    // shape means the same thing from one visit to the next.
     const values: Record<string, number> = {};
-    for (const domain of DOMAINS) {
-        const peak = core
-            .filter((s) => CATEGORY_TO_DOMAIN[s.category] === domain)
-            .reduce((max, s) => Math.max(max, pct(s.level)), 0);
-        values[domain] = peak;
-    }
-    const metrics = DOMAINS.map((d) => ({ key: d, label: d }));
-    const radarData = [{ label: 'Proficiency', values }];
+    for (const bucket of buckets) values[bucket.name] = bucket.peak;
+    const metrics = buckets.map((b) => ({ key: b.name, label: b.name }));
+    const radarData = [{ label: 'Peak proficiency', values }];
+
+    // Rings — how much of the toolbox each category accounts for. The widest
+    // category fills its ring, so the rest read as shares of it; the exact
+    // counts are in the legend and the centre carries the total.
+    const ranked = [...buckets].sort((a, b) => b.count - a.count || b.peak - a.peak);
+    const widest = ranked[0].count;
+    const rings = ranked.map((b, i) => ({
+        label: b.name,
+        value: b.count,
+        maxValue: widest,
+        peak: b.peak,
+        color: `var(--chart-ramp-${Math.min(i + 1, RAMP_STEPS)})`,
+    }));
 
     return (
         <div className='flex flex-col gap-10'>
             <GithubHeatmap />
 
-            <figure className='flex flex-col items-center'>
-                <RadarChart data={radarData} metrics={metrics} className='mx-auto max-w-[380px]'>
-                    <RadarGrid />
-                    <RadarAxis />
-                    <RadarArea index={0} showGlow />
-                    <RadarLabels />
-                </RadarChart>
-                <figcaption className='mt-2 font-mono text-xs uppercase tracking-wider text-content-accent'>
-                    // domain proficiency
-                </figcaption>
-            </figure>
+            <div className='grid gap-8 md:grid-cols-2'>
+                <figure className='flex flex-col items-center gap-3'>
+                    <RadarChart data={radarData} metrics={metrics} className='mx-auto max-w-[380px]'>
+                        <RadarGrid />
+                        <RadarAxis />
+                        <RadarArea index={0} showGlow />
+                        <RadarLabels />
+                    </RadarChart>
+                    <figcaption className='flex flex-col items-center gap-1 font-mono text-xs uppercase tracking-wider text-content-accent'>
+                        // peak proficiency by category
+                        <span className='sr-only'>
+                            {buckets.map((b) => `${b.name}: ${b.peak}%`).join(', ')}
+                        </span>
+                    </figcaption>
+                </figure>
+
+                <figure className='flex flex-col items-center gap-3'>
+                    <RingChart
+                        data={rings}
+                        className='mx-auto max-w-[280px]'
+                        strokeWidth={11}
+                        ringGap={5}
+                        baseInnerRadius={44}
+                    >
+                        {rings.map((r, i) => (
+                            <Ring key={r.label} index={i} showGlow />
+                        ))}
+                        <RingCenter defaultLabel='Tools' />
+                    </RingChart>
+                    <figcaption className='flex w-full flex-col items-center gap-2 font-mono text-xs uppercase tracking-wider text-content-accent'>
+                        // toolbox by category
+                        <ul className='m-0 flex w-full max-w-[300px] list-none flex-col gap-1 p-0 normal-case tracking-normal'>
+                            {rings.map((r) => (
+                                <li key={r.label} className='flex items-baseline justify-between gap-3 text-[0.68rem]'>
+                                    <span className='flex items-center gap-1.5 text-content-subtitle'>
+                                        <span
+                                            aria-hidden='true'
+                                            className='inline-block h-2 w-2 shrink-0 rounded-full'
+                                            style={{ backgroundColor: r.color }}
+                                        />
+                                        {r.label}
+                                    </span>
+                                    <span className='tabular whitespace-nowrap'>
+                                        {r.value} · peak {r.peak}%
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </figcaption>
+                </figure>
+            </div>
         </div>
     );
 }

--- a/website/src/utils/skillTaxonomy.ts
+++ b/website/src/utils/skillTaxonomy.ts
@@ -1,0 +1,86 @@
+/**
+ * One taxonomy for the Rolling Stock list, shared by the toolbox drawers and
+ * the two charts above them.
+ *
+ * Every tool in skill_data.json carries exactly one `category`, drawn from this
+ * list. The data had twenty of them once, half a single tool deep ("AI Gateway",
+ * "Endpoint (MDM)", "Game Development"), which made grouping arbitrary and
+ * scoring meaningless:
+ *
+ *   Cloud        the public clouds themselves
+ *   Platform     what runs on them — IaC, CI/CD, containers, observability, repos
+ *   Security     identity, endpoint posture, network, vulnerability, offensive
+ *   Development  languages and the web stack
+ *   Workplace    the endpoints and the tools the company works in
+ *   Creative     the pre-engineering craft — real-time, 3D, VFX, design
+ *
+ * Grouping still reads whatever category a tool actually carries, so a new one
+ * shows up as its own group instead of vanishing — the list above is the
+ * intent, not a filter.
+ */
+export const CATEGORIES = ['Cloud', 'Platform', 'Security', 'Development', 'Workplace', 'Creative'];
+
+/** Where a tool with no category at all ends up. */
+export const UNCATEGORISED = 'Other';
+
+/** Sequential ramp steps available for group colours. See --chart-ramp-* in index.css. */
+const RAMP_STEPS = 6;
+
+export type SkillLike = { name: string; category?: string; level?: string };
+
+export type SkillGroup<T extends SkillLike = SkillLike> = {
+    /** Category name, as carried by the tools in it */
+    name: string;
+    /** Its tools, strongest first */
+    skills: T[];
+    count: number;
+    /** Best tool in the group */
+    peak: number;
+    /** Mean across the group — how deep it runs, rather than how high it reaches */
+    avg: number;
+};
+
+export const pct = (level?: string) => parseInt(String(level).replace('%', ''), 10) || 0;
+
+/**
+ * Group tools by category, biggest group first. Ties break on the deeper group,
+ * so the order is stable for a given data set and matches the ring chart.
+ */
+export function groupSkills<T extends SkillLike>(skills: T[]): SkillGroup<T>[] {
+    const byCategory = new Map<string, T[]>();
+    for (const skill of skills) {
+        const key = skill.category || UNCATEGORISED;
+        const bucket = byCategory.get(key);
+        if (bucket) bucket.push(skill);
+        else byCategory.set(key, [skill]);
+    }
+
+    return [...byCategory.entries()]
+        .map(([name, group]) => {
+            const levels = group.map((s) => pct(s.level));
+            return {
+                name,
+                skills: [...group].sort((a, b) => pct(b.level) - pct(a.level)),
+                count: group.length,
+                peak: levels.reduce((max, v) => Math.max(max, v), 0),
+                avg: Math.round(levels.reduce((a, b) => a + b, 0) / levels.length),
+            };
+        })
+        .sort((a, b) => b.count - a.count || b.avg - a.avg || a.name.localeCompare(b.name));
+}
+
+/**
+ * Taxonomy order — for the radar, whose axes should mean the same thing from one
+ * visit to the next rather than shuffling when a tool is added. Categories off
+ * the canonical list sort to the end, alphabetically.
+ */
+export function byTaxonomyOrder(a: { name: string }, b: { name: string }): number {
+    const rank = (name: string) => {
+        const i = CATEGORIES.indexOf(name);
+        return i === -1 ? CATEGORIES.length : i;
+    };
+    return rank(a.name) - rank(b.name) || a.name.localeCompare(b.name);
+}
+
+/** Ramp step for a group at `index` in the grouped order (brightest = biggest). */
+export const rampColor = (index: number) => `var(--chart-ramp-${Math.min(index + 1, RAMP_STEPS)})`;


### PR DESCRIPTION
## Summary
Restructured the skills display to use a unified taxonomy system and introduced a complementary ring chart alongside the existing radar chart. The radar now shows both peak and average proficiency per category, while the new ring chart displays toolbox breadth with an accompanying data table.

## Key Changes

- **New Taxonomy System** (`skillTaxonomy.ts`): Created a centralized skill grouping utility that consolidates 20+ granular categories into 6 canonical ones (Cloud, Platform, Security, Development, Workplace, Creative). Provides shared functions for grouping, sorting, and color mapping used across all skill components.

- **Dual Radar Visualization**: Enhanced the radar chart to display two data series:
  - Peak proficiency (outer envelope, amber color)
  - Average proficiency (solid core, green color)
  - Axes now maintain consistent taxonomy order across visits

- **New Ring Chart**: Added a complementary visualization showing toolbox breadth:
  - Concentric rings represent each category, sized by tool count
  - Widest category fills its ring; others show proportional shares
  - Includes a center label and glow effects

- **Data Table**: Added an accompanying table beneath the ring chart displaying:
  - Tool count per category
  - Average and peak proficiency percentages
  - Color-coded category indicators

- **Refactored Skill Highlight**: Converted the flat skill list into collapsible category drawers:
  - Groups organized by size (biggest first)
  - Closed by default to reduce visual clutter
  - Consistent color ramp with ring chart
  - Displays category metadata (tool count, average proficiency)

- **Updated Skill Data**: Consolidated skill categories across both production and development datasets to match the new taxonomy (e.g., "Automation" → "Platform", "Programming Language" → "Development")

- **CSS Enhancements**: Added a 6-step sequential color ramp (`--chart-ramp-1` through `--chart-ramp-6`) in signal green for magnitude encoding in the ring chart

## Implementation Details

- The `groupSkills()` function sorts groups by count (descending), then average proficiency, ensuring stable and meaningful ordering
- `byTaxonomyOrder()` maintains radar axis consistency by following the canonical category list
- `rampColor()` maps group indices to CSS variables, cycling through available steps
- New `SeriesKey` component provides consistent legend styling across charts
- All skill components now share the same grouping logic and visual language

https://claude.ai/code/session_01QDaXrsFa6iwz6JxNhxDNLt