### PR TITLE
Reconcile the Skills page with the current resume

### DIFF
--- a/website/src/assets/css/index.css
+++ b/website/src/assets/css/index.css
@@ -143,15 +143,20 @@
     /* Ring ramp — a one-hue sequential scale in signal green, brightest step
        first. The rings encode magnitude (how many tools sit in a category), so
        lightness carries the value and hue stays out of it; the categorical
-       --chart-1..5 slots are for charts where colour means identity. Steps are
-       ~0.07 apart in OKLCH lightness, so each reads as its own step against the
-       dark surface, and the darkest still clears 3:1 against it. */
+       --chart-1..5 slots are for charts where colour means identity.
+       The seventh category (AI) needed a seventh step, and the ramp had no room
+       below it: continuing at the old ~0.07 spacing landed at 2.83:1, under the
+       3:1 floor. So the range is unchanged at both ends and the steps are
+       redistributed — ~0.058 apart in OKLCH lightness rather than ~0.07. Each
+       still reads as its own step against the dark surface, and the darkest
+       still clears 3:1 against it (3.74:1). */
     --chart-ramp-1: #6effad;
-    --chart-ramp-2: #0fec8e;
-    --chart-ramp-3: #1bd27e;
-    --chart-ramp-4: #10b86e;
-    --chart-ramp-5: #04a05e;
-    --chart-ramp-6: #0e8750;
+    --chart-ramp-2: #2eef93;
+    --chart-ramp-3: #18da83;
+    --chart-ramp-4: #16c576;
+    --chart-ramp-5: #0cb069;
+    --chart-ramp-6: #069b5b;
+    --chart-ramp-7: #0e8750;
 }
 
 /* Scrollbar-width compensation */

--- a/website/src/assets/json/production/career_data.json
+++ b/website/src/assets/json/production/career_data.json
@@ -86,9 +86,14 @@
           "website": "https://www.terraform.io/"
         },
         {
-          "name": "Atlassian Suite",
-          "logo": "simple-icons:atlassian",
-          "website": "https://www.atlassian.com"
+          "name": "Jira",
+          "logo": "simple-icons:jira",
+          "website": "https://www.atlassian.com/software/jira"
+        },
+        {
+          "name": "Confluence",
+          "logo": "simple-icons:confluence",
+          "website": "https://www.atlassian.com/software/confluence"
         },
         {
           "name": "CloudFlare",

--- a/website/src/assets/json/production/career_data.json
+++ b/website/src/assets/json/production/career_data.json
@@ -53,9 +53,9 @@
           "website": "https://www.python.org"
         },
         {
-          "name": "Google Suite",
+          "name": "Google Workspace",
           "logo": "simple-icons:google",
-          "website": "https://www.google.com"
+          "website": "https://workspace.google.com/"
         }
       ]
     },
@@ -101,9 +101,9 @@
           "website": "https://www.cloudflare.com"
         },
         {
-          "name": "Google Suite",
+          "name": "Google Workspace",
           "logo": "simple-icons:google",
-          "website": "https://www.google.com"
+          "website": "https://workspace.google.com/"
         },
         {
           "name": "GitLab",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -386,6 +386,13 @@
       "website": "https://tailwindcss.com"
     },
     {
+      "name": "Xcode",
+      "category": "Development",
+      "level": "35%",
+      "logo": "logos:xcode",
+      "website": "https://developer.apple.com/xcode/"
+    },
+    {
       "name": "IntelliJ IDEA",
       "category": "Development",
       "level": "45%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -155,6 +155,34 @@
       "website": "https://northpole.security/santa"
     },
     {
+      "name": "Okta Identity Governance",
+      "category": "Security",
+      "level": "65%",
+      "logo": "devicon-plain:okta",
+      "website": "https://www.okta.com/products/identity-governance/"
+    },
+    {
+      "name": "Dependabot",
+      "category": "Security",
+      "level": "50%",
+      "logo": "simple-icons:dependabot",
+      "website": "https://docs.github.com/en/code-security/dependabot"
+    },
+    {
+      "name": "AWS Certificate Manager",
+      "category": "Security",
+      "level": "40%",
+      "logo": "logos:aws-certificate-manager",
+      "website": "https://aws.amazon.com/certificate-manager/"
+    },
+    {
+      "name": "Trivy",
+      "category": "Security",
+      "level": "30%",
+      "logo": "simple-icons:trivy",
+      "website": "https://trivy.dev/"
+    },
+    {
       "name": "Grafana",
       "category": "Platform",
       "level": "50%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -190,13 +190,6 @@
       "website": "https://slack.com/"
     },
     {
-      "name": "Atlassian",
-      "category": "Workplace",
-      "level": "75%",
-      "logo": "simple-icons:atlassian",
-      "website": "https://www.atlassian.com/"
-    },
-    {
       "name": "Google Workspace",
       "category": "Workplace",
       "level": "70%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -162,6 +162,20 @@
       "website": "https://workbrew.com/"
     },
     {
+      "name": "Splunk",
+      "category": "Security",
+      "level": "45%",
+      "logo": "simple-icons:splunk",
+      "website": "https://www.splunk.com/"
+    },
+    {
+      "name": "FleetDM",
+      "category": "Security",
+      "level": "35%",
+      "logo": "selfhst:fleet-dm",
+      "website": "https://fleetdm.com/"
+    },
+    {
       "name": "Okta Identity Governance",
       "category": "Security",
       "level": "65%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -50,6 +50,13 @@
       "website": "https://www.okta.com/"
     },
     {
+      "name": "1Password",
+      "category": "Security",
+      "level": "90%",
+      "logo": "simple-icons:1password",
+      "website": "https://1password.com/"
+    },
+    {
       "name": "Entra ID",
       "category": "Security",
       "level": "45%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -379,6 +379,41 @@
       "website": "https://tailwindcss.com"
     },
     {
+      "name": "IntelliJ IDEA",
+      "category": "Development",
+      "level": "45%",
+      "logo": "logos:intellij-idea",
+      "website": "https://www.jetbrains.com/idea/"
+    },
+    {
+      "name": "PyCharm",
+      "category": "Development",
+      "level": "60%",
+      "logo": "skill-icons:pycharm-light",
+      "website": "https://www.jetbrains.com/pycharm/"
+    },
+    {
+      "name": "Rider",
+      "category": "Development",
+      "level": "45%",
+      "logo": "skill-icons:rider-light",
+      "website": "https://www.jetbrains.com/rider/"
+    },
+    {
+      "name": "CLion",
+      "category": "Development",
+      "level": "35%",
+      "logo": "skill-icons:clion-light",
+      "website": "https://www.jetbrains.com/clion/"
+    },
+    {
+      "name": "JetBrains Air",
+      "category": "Development",
+      "level": "25%",
+      "logo": "simple-icons:jetbrains",
+      "website": "https://www.jetbrains.com/air/"
+    },
+    {
       "name": "SideFX Houdini",
       "category": "Creative",
       "level": "30%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -148,6 +148,13 @@
       "website": "https://dope.security/"
     },
     {
+      "name": "Santa",
+      "category": "Security",
+      "level": "60%",
+      "logo": null,
+      "website": "https://northpole.security/santa"
+    },
+    {
       "name": "Grafana",
       "category": "Platform",
       "level": "50%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -155,6 +155,13 @@
       "website": "https://northpole.security/santa"
     },
     {
+      "name": "Workbrew",
+      "category": "Security",
+      "level": "70%",
+      "logo": null,
+      "website": "https://workbrew.com/"
+    },
+    {
       "name": "Okta Identity Governance",
       "category": "Security",
       "level": "65%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -127,6 +127,20 @@
       "website": "https://www.jupiterone.com/"
     },
     {
+      "name": "Cyberhaven",
+      "category": "Security",
+      "level": "50%",
+      "logo": null,
+      "website": "https://www.cyberhaven.com/"
+    },
+    {
+      "name": "dope.security",
+      "category": "Security",
+      "level": "50%",
+      "logo": null,
+      "website": "https://dope.security/"
+    },
+    {
       "name": "Grafana",
       "category": "Platform",
       "level": "50%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -64,6 +64,13 @@
       "website": "https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id"
     },
     {
+      "name": "Push Security",
+      "category": "Security",
+      "level": "45%",
+      "logo": null,
+      "website": "https://pushsecurity.com/"
+    },
+    {
       "name": "Go",
       "category": "Development",
       "level": "55%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -253,6 +253,13 @@
       "website": "https://claude.com/"
     },
     {
+      "name": "Gemini",
+      "category": "AI",
+      "level": "60%",
+      "logo": "simple-icons:googlegemini",
+      "website": "https://gemini.google.com/"
+    },
+    {
       "name": "Codex",
       "category": "AI",
       "level": "45%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -94,7 +94,7 @@
     {
       "name": "Zscaler",
       "category": "Security",
-      "level": "55%",
+      "level": "65%",
       "logo": null,
       "website": "https://www.zscaler.com/"
     },
@@ -136,7 +136,7 @@
     {
       "name": "dope.security",
       "category": "Security",
-      "level": "50%",
+      "level": "80%",
       "logo": null,
       "website": "https://dope.security/"
     },

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -3,21 +3,21 @@
     {
       "name": "Amazon Web Services",
       "category": "Cloud",
-      "level": "80%",
+      "level": "70%",
       "logo": "skill-icons:aws-light",
       "website": "https://aws.amazon.com/"
     },
     {
       "name": "Microsoft Azure",
       "category": "Cloud",
-      "level": "14%",
+      "level": "20%",
       "logo": "skill-icons:azure-light",
       "website": "https://azure.microsoft.com/"
     },
     {
       "name": "Google Cloud Platform",
       "category": "Cloud",
-      "level": "12%",
+      "level": "25%",
       "logo": "skill-icons:gcp-light",
       "website": "https://cloud.google.com/"
     },
@@ -45,7 +45,7 @@
     {
       "name": "Okta",
       "category": "Security",
-      "level": "85%",
+      "level": "80%",
       "logo": "devicon-plain:okta",
       "website": "https://www.okta.com/"
     },
@@ -85,7 +85,14 @@
       "website": "https://helm.sh/"
     },
     {
-      "name": "CrowdStrike Falcon",
+      "name": "ArgoCD",
+      "category": "Platform",
+      "level": "35%",
+      "logo": "simple-icons:argo",
+      "website": "https://argo-cd.readthedocs.io/"
+    },
+    {
+      "name": "CrowdStrike",
       "category": "Security",
       "level": "65%",
       "logo": null,
@@ -108,21 +115,21 @@
     {
       "name": "Tailscale",
       "category": "Security",
-      "level": "55%",
+      "level": "60%",
       "logo": "simple-icons:tailscale",
       "website": "https://tailscale.com/"
     },
     {
       "name": "Iru",
       "category": "Security",
-      "level": "75%",
+      "level": "85%",
       "logo": null,
       "website": "https://www.iru.com/"
     },
     {
       "name": "JupiterOne",
       "category": "Security",
-      "level": "50%",
+      "level": "40%",
       "logo": null,
       "website": "https://www.jupiterone.com/"
     },
@@ -150,7 +157,7 @@
     {
       "name": "LiteLLM",
       "category": "AI",
-      "level": "65%",
+      "level": "70%",
       "logo": "selfhst:litellm",
       "website": "https://www.litellm.ai/"
     },
@@ -190,6 +197,27 @@
       "website": "https://www.atlassian.com/"
     },
     {
+      "name": "Google Workspace",
+      "category": "Workplace",
+      "level": "70%",
+      "logo": "logos:google-workspace",
+      "website": "https://workspace.google.com/"
+    },
+    {
+      "name": "Confluence",
+      "category": "Workplace",
+      "level": "60%",
+      "logo": "simple-icons:confluence",
+      "website": "https://www.atlassian.com/software/confluence"
+    },
+    {
+      "name": "Jira",
+      "category": "Workplace",
+      "level": "60%",
+      "logo": "simple-icons:jira",
+      "website": "https://www.atlassian.com/software/jira"
+    },
+    {
       "name": "Unreal Engine",
       "category": "Creative",
       "level": "60%",
@@ -220,14 +248,14 @@
     {
       "name": "C++",
       "category": "Development",
-      "level": "30%",
+      "level": "35%",
       "logo": "skill-icons:cpp",
       "website": "https://cplusplus.com/"
     },
     {
       "name": "Python",
       "category": "Development",
-      "level": "45%",
+      "level": "60%",
       "logo": "skill-icons:python-light",
       "website": "https://www.python.org"
     },
@@ -248,7 +276,7 @@
     {
       "name": "TypeScript",
       "category": "Development",
-      "level": "30%",
+      "level": "40%",
       "logo": "skill-icons:typescript",
       "website": "https://www.typescriptlang.org"
     },
@@ -262,7 +290,7 @@
     {
       "name": "Next.js",
       "category": "Development",
-      "level": "35%",
+      "level": "45%",
       "logo": "skill-icons:nextjs-light",
       "website": "https://nextjs.org/"
     },
@@ -304,7 +332,7 @@
     {
       "name": "Windows",
       "category": "Workplace",
-      "level": "100%",
+      "level": "95%",
       "logo": "skill-icons:windows-light",
       "website": "https://www.microsoft.com/en-us/windows"
     },

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -395,7 +395,7 @@
     {
       "name": "Windows",
       "category": "Workplace",
-      "level": "95%",
+      "level": "90%",
       "logo": "skill-icons:windows-light",
       "website": "https://www.microsoft.com/en-us/windows"
     },

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -135,17 +135,31 @@
     },
     {
       "name": "LiteLLM",
-      "category": "Platform",
+      "category": "AI",
       "level": "65%",
       "logo": "selfhst:litellm",
       "website": "https://www.litellm.ai/"
     },
     {
       "name": "AWS Bedrock",
-      "category": "Platform",
+      "category": "AI",
       "level": "50%",
       "logo": "simple-icons:amazonwebservices",
       "website": "https://aws.amazon.com/bedrock/"
+    },
+    {
+      "name": "Claude",
+      "category": "AI",
+      "level": "75%",
+      "logo": "simple-icons:claude",
+      "website": "https://claude.com/"
+    },
+    {
+      "name": "Codex",
+      "category": "AI",
+      "level": "45%",
+      "logo": "simple-icons:openai",
+      "website": "https://openai.com/codex/"
     },
     {
       "name": "Slack",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -127,6 +127,13 @@
       "website": "https://tailscale.com/"
     },
     {
+      "name": "UniFi",
+      "category": "Security",
+      "level": "50%",
+      "logo": "selfhst:ubiquiti-unifi",
+      "website": "https://ui.com/"
+    },
+    {
       "name": "Iru",
       "category": "Security",
       "level": "85%",

--- a/website/src/assets/json/production/skill_data.json
+++ b/website/src/assets/json/production/skill_data.json
@@ -45,9 +45,16 @@
     {
       "name": "Okta",
       "category": "Security",
-      "level": "80%",
+      "level": "85%",
       "logo": "devicon-plain:okta",
       "website": "https://www.okta.com/"
+    },
+    {
+      "name": "Entra ID",
+      "category": "Security",
+      "level": "45%",
+      "logo": null,
+      "website": "https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id"
     },
     {
       "name": "Go",
@@ -80,21 +87,21 @@
     {
       "name": "CrowdStrike Falcon",
       "category": "Security",
-      "level": "55%",
+      "level": "65%",
       "logo": null,
       "website": "https://www.crowdstrike.com/"
     },
     {
       "name": "Zscaler",
       "category": "Security",
-      "level": "50%",
+      "level": "55%",
       "logo": null,
       "website": "https://www.zscaler.com/"
     },
     {
       "name": "Qualys",
       "category": "Security",
-      "level": "50%",
+      "level": "60%",
       "logo": "simple-icons:qualys",
       "website": "https://www.qualys.com/"
     },
@@ -106,11 +113,18 @@
       "website": "https://tailscale.com/"
     },
     {
-      "name": "Kandji",
+      "name": "Iru",
       "category": "Security",
-      "level": "60%",
+      "level": "75%",
       "logo": null,
-      "website": "https://www.kandji.io/"
+      "website": "https://www.iru.com/"
+    },
+    {
+      "name": "JupiterOne",
+      "category": "Security",
+      "level": "50%",
+      "logo": null,
+      "website": "https://www.jupiterone.com/"
     },
     {
       "name": "Grafana",
@@ -122,9 +136,16 @@
     {
       "name": "LiteLLM",
       "category": "Platform",
-      "level": "50%",
+      "level": "65%",
       "logo": "selfhst:litellm",
       "website": "https://www.litellm.ai/"
+    },
+    {
+      "name": "AWS Bedrock",
+      "category": "Platform",
+      "level": "50%",
+      "logo": "simple-icons:amazonwebservices",
+      "website": "https://aws.amazon.com/bedrock/"
     },
     {
       "name": "Slack",
@@ -160,6 +181,13 @@
       "level": "50%",
       "logo": "simple-icons:perforce",
       "website": "https://www.perforce.com/"
+    },
+    {
+      "name": "Swift",
+      "category": "Development",
+      "level": "55%",
+      "logo": "skill-icons:swift",
+      "website": "https://www.swift.org/"
     },
     {
       "name": "C++",
@@ -253,6 +281,20 @@
       "website": "https://www.microsoft.com/en-us/windows"
     },
     {
+      "name": "Linux",
+      "category": "Workplace",
+      "level": "70%",
+      "logo": "skill-icons:linux-light",
+      "website": "https://www.kernel.org/"
+    },
+    {
+      "name": "Microsoft 365",
+      "category": "Workplace",
+      "level": "65%",
+      "logo": "selfhst:microsoft-365",
+      "website": "https://www.microsoft.com/en-us/microsoft-365"
+    },
+    {
       "name": "Kali Linux",
       "category": "Security",
       "level": "40%",
@@ -262,7 +304,7 @@
     {
       "name": "macOS",
       "category": "Workplace",
-      "level": "70%",
+      "level": "75%",
       "logo": "skill-icons:apple-light",
       "website": "https://www.apple.com"
     }
@@ -298,7 +340,10 @@
     { "name": "Kubernetes Access Control & RBAC" },
     { "name": "Enterprise AI Governance & AI Tooling Security" },
     { "name": "Identity Federation (SAML, OAuth 2.0, OIDC, SCIM)" },
-    { "name": "Compliance-Driven Security Controls (NIST-Aligned Hardening)" }
+    { "name": "Threat Mitigation" },
+    { "name": "Risk Management" },
+    { "name": "Agile & DevOps" },
+    { "name": "Regulatory & Compliance Controls (NIST-Aligned Hardening, CIS Benchmarks, ISO 27001, GDPR)" }
   ],
   "soft_skills": [
     { "name": "Cross-Functional Stakeholder Communication" },

--- a/website/src/utils/skillTaxonomy.ts
+++ b/website/src/utils/skillTaxonomy.ts
@@ -9,22 +9,28 @@
  *
  *   Cloud        the public clouds themselves
  *   Platform     what runs on them — IaC, CI/CD, containers, observability, repos
+ *   AI           the gateway, the model platforms, and the coding agents
  *   Security     identity, endpoint posture, network, vulnerability, offensive
  *   Development  languages and the web stack
  *   Workplace    the endpoints and the tools the company works in
  *   Creative     the pre-engineering craft — real-time, 3D, VFX, design
  *
+ * AI is the one category that came back. It was cut in the collapse above as
+ * "AI Gateway", a single tool deep and therefore arbitrary; it now carries four
+ * and names a distinct pillar of the work, which is the bar the rest of this
+ * list is held to.
+ *
  * Grouping still reads whatever category a tool actually carries, so a new one
  * shows up as its own group instead of vanishing — the list above is the
  * intent, not a filter.
  */
-export const CATEGORIES = ['Cloud', 'Platform', 'Security', 'Development', 'Workplace', 'Creative'];
+export const CATEGORIES = ['Cloud', 'Platform', 'AI', 'Security', 'Development', 'Workplace', 'Creative'];
 
 /** Where a tool with no category at all ends up. */
 export const UNCATEGORISED = 'Other';
 
 /** Sequential ramp steps available for group colours. See --chart-ramp-* in index.css. */
-const RAMP_STEPS = 6;
+const RAMP_STEPS = 7;
 
 export type SkillLike = { name: string; category?: string; level?: string };
 


### PR DESCRIPTION
Started as a review of the resume against `skill_data.json` and grew into a full pass over the toolbox. The Skills page goes from 39 tools to 69, across 7 categories instead of 6.

## Data

**New categories.** `AI` joins the taxonomy between Platform and Security, holding LiteLLM, AWS Bedrock, Claude, Gemini and Codex. It had been cut once as "AI Gateway" for being a single tool deep; at five it clears the same bar the rest of the list is held to, and it names a pillar of the current role that was previously scattered across Platform.

**New tools.** Security gained most of them — 1Password, Iru, dope.security, Workbrew, Okta Identity Governance, Santa, Cyberhaven, Splunk, UniFi, Push Security, Dependabot, AWS Certificate Manager, FleetDM, JupiterOne, Trivy, Entra ID. Development gained Swift, the JetBrains IDEs, Xcode and JetBrains Air. Platform gained ArgoCD; Workplace gained Linux, Microsoft 365, Google Workspace, Jira and Confluence.

**Stale brands fixed.** Kandji rebranded to Iru in October 2025 (entry and URL were both dead). "CrowdStrike Falcon" shortened to "CrowdStrike". The Atlassian umbrella tile gave way to Jira and Confluence, and the matching `Atlassian Suite` / `Google Suite` tech tags in `career_data.json` were updated to match.

**Levels reweighted** across every category, mostly where the resume shows ownership rather than familiarity.

**Industry knowledge** gained Threat Mitigation, Risk Management and Agile & DevOps, and the compliance tag widened to name CIS Benchmarks, ISO 27001 and GDPR as the resume does. Four tags that asserted capability with no tool behind them — PKI, supply-chain security, access governance, incident response — now have one.

## Code

Two changes, both forced by the seventh category rather than chosen:

- `skillTaxonomy.ts` — `'AI'` added to `CATEGORIES` so the radar places it deliberately instead of sorting it to the end as unknown; `RAMP_STEPS` 6 → 7.
- `index.css` — the ring ramp had exactly six steps, and `rampColor` clamps with `Math.min`, so groups 6 and 7 would have rendered the identical green. Adding a seventh step at the ramp's documented ~0.07 OKLCH spacing lands at 2.83:1 against `--chart-background`, under the 3:1 floor the ramp commits to, and step 6 was already at 3.74:1 with no headroom. So the range is redistributed instead: both endpoints unchanged, seven even steps ~0.058 apart, all clearing 3:1 with the darkest at 3.74:1. Steps 2–6 shift slightly as a result.

## Verification

Not run and not rendered — `npm install` fails with repeated `ECONNRESET` against the registry in the environment this was authored in, so neither vitest nor a browser was available. Everything below is static:

- JSON parses across all production data files
- All 112 icon references resolve against the real Iconify sets, checked offline against `@iconify-json/*` packages
- Monograms for the marks Iconify does not publish were confirmed by executing `monogramFor()` directly — 10 tiles fall back, all unique
- No other code assumes 6 categories or 6 ramp steps; no test touches `skillTaxonomy`, `groupSkills` or `rampColor`
- Both charts map over all groups without slicing, so 7 renders

**The ramp change is the one piece that wants a human eye** — those hex values were derived by computation and the ring chart was never seen drawing them.

## Worth a look before merging

- Windows 90 and 1Password 90 are the joint-highest on the page, above Okta at 80 — the platform the resume actually quantifies.
- Cloud averages 38% and sits last despite three AWS certifications, because Azure 20 and GCP 25 drag AWS 70 down.
- Security is 22 of 69 tools. The drawer opens to a wall of them, which is what the collapsed-drawer design exists to avoid; splitting Identity / Endpoint / AppSec is worth considering.
- Category order is still count-first, so Development sits second on avg 45% while AI at 60% and Workplace at 71% sit below it.
- Rider implies C#, which appears nowhere else on the page.
- JetBrains Air's 25% is a placeholder — no level was specified and there is no language to anchor it to.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRNq8bmS9cbiixFYLdp3H2)_