### PR TITLE
fix(iam): grant OIDC provider management perms to tf-oidc-role

### DIFF
--- a/infrastructure/modules/iam/data.tf
+++ b/infrastructure/modules/iam/data.tf
@@ -229,7 +229,12 @@ data "aws_iam_policy_document" "crc-github-terraform-limited-iam" {
       "iam:CreateUser",
       "iam:DeleteUser",
       "iam:DeleteAccessKey",
-      "iam:CreateAccessKey"
+      "iam:CreateAccessKey",
+      "iam:CreateOpenIDConnectProvider",
+      "iam:DeleteOpenIDConnectProvider",
+      "iam:UpdateOpenIDConnectProviderThumbprint",
+      "iam:AddClientIDToOpenIDConnectProvider",
+      "iam:RemoveClientIDFromOpenIDConnectProvider"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Summary
- CI failed applying `module.iam_github_oidc_provider` with `AccessDenied` on `iam:UpdateOpenIDConnectProviderThumbprint` (run: https://github.com/RetroHazard/CloudResume/actions/runs/30196981127/job/89780209865)
- The `crc-github-terraform-limited-iam` policy (`infrastructure/modules/iam/data.tf`) only grants wildcard `iam:Get*`/`iam:List*`/`iam:Tag*`/`iam:Untag*` actions, which don't cover the OIDC-provider-specific actions the `terraform-aws-modules/iam/aws//modules/iam-github-oidc-provider` module needs to manage the `aws_iam_openid_connect_provider` resource
- Added the missing actions to the policy: `iam:CreateOpenIDConnectProvider`, `iam:DeleteOpenIDConnectProvider`, `iam:UpdateOpenIDConnectProviderThumbprint`, `iam:AddClientIDToOpenIDConnectProvider`, `iam:RemoveClientIDFromOpenIDConnectProvider`

## Test plan
- [ ] Re-run the Terraform Apply workflow and confirm `module.iam_github_oidc_provider.aws_iam_openid_connect_provider.this[0]` applies without `AccessDenied`

---
_Generated by [Claude Code](https://claude.ai/code/session_016N9Er356nRwHXXfzQQ81kd)_