### PR TITLE
Sync transit map trains to Tokyo service timetable

### DIFF
--- a/website/src/__tests__/TransitBackground.test.js
+++ b/website/src/__tests__/TransitBackground.test.js
@@ -1,0 +1,91 @@
+import { act, render } from '@testing-library/react';
+import TransitBackground from '../components/TransitBackground';
+
+// The backdrop runs to the same Tokyo timetable as the header badge: a full
+// fleet in working hours, fewer and slower trains off-peak, and everything
+// stabled overnight. The map itself is random per load, so these assertions
+// count trains and read durations rather than pinning geometry.
+describe('TransitBackground timetable', () => {
+    const runningTrains = (container) => container.querySelectorAll('animateMotion');
+    // Stabled trains are the white dots pinned to a depot; stations are darker.
+    const stabledTrains = (container) => container.querySelectorAll('circle[fill="#ffffff"][cx]');
+
+    const renderAt = (iso) => {
+        vi.setSystemTime(new Date(iso));
+        return render(<TransitBackground />);
+    };
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test('works every line during full service', () => {
+        const { container } = renderAt('2026-07-25T04:20:00Z'); // 13:20 JST
+        expect(runningTrains(container)).toHaveLength(4);
+        expect(stabledTrains(container)).toHaveLength(0);
+    });
+
+    test('thins the service off-peak', () => {
+        const { container } = renderAt('2026-07-24T22:00:00Z'); // 07:00 JST
+        expect(runningTrains(container)).toHaveLength(2);
+    });
+
+    test('runs a single train on the last-train band', () => {
+        const { container } = renderAt('2026-07-25T14:00:00Z'); // 23:00 JST
+        expect(runningTrains(container)).toHaveLength(1);
+    });
+
+    test('stables the whole fleet during the overnight shutdown', () => {
+        const { container } = renderAt('2026-07-24T18:00:00Z'); // 03:00 JST
+        expect(runningTrains(container)).toHaveLength(0);
+        expect(stabledTrains(container)).toHaveLength(4);
+    });
+
+    test('runs the late train slower than a daytime one', () => {
+        // Base durations are 10–17s: full service leaves them alone, the
+        // last-train band stretches them well past 20s.
+        const day = renderAt('2026-07-25T04:20:00Z'); // 13:20 JST
+        const dayDur = Number(runningTrains(day.container)[0].getAttribute('dur').replace('s', ''));
+        expect(dayDur).toBeLessThan(18);
+
+        const night = renderAt('2026-07-25T14:00:00Z'); // 23:00 JST
+        const nightDur = Number(runningTrains(night.container)[0].getAttribute('dur').replace('s', ''));
+        expect(nightDur).toBeGreaterThan(20);
+    });
+
+    test('picks the service back up when the shutdown ends under an open tab', () => {
+        const { container } = renderAt('2026-07-24T20:59:30Z'); // 05:59:30 JST
+        expect(runningTrains(container)).toHaveLength(0);
+
+        act(() => vi.advanceTimersByTime(60000)); // → 06:00:30 JST, reduced service
+        expect(runningTrains(container)).toHaveLength(2);
+        expect(stabledTrains(container)).toHaveLength(0);
+    });
+});
+
+describe('TransitBackground with reduced motion', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.doMock('motion/react', () => ({ useReducedMotion: () => true }));
+    });
+
+    afterEach(() => {
+        vi.doUnmock('motion/react');
+        vi.resetModules();
+    });
+
+    test('holds the fleet at the platforms instead of animating it', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-25T04:20:00Z')); // 13:20 JST, full service
+        const { default: Background } = await import('../components/TransitBackground');
+        const { container } = render(<Background />);
+
+        expect(container.querySelectorAll('animateMotion')).toHaveLength(0);
+        expect(container.querySelectorAll('circle[fill="#ffffff"][cx]')).toHaveLength(4);
+        vi.useRealTimers();
+    });
+});

--- a/website/src/__tests__/serviceStatus.test.js
+++ b/website/src/__tests__/serviceStatus.test.js
@@ -2,6 +2,7 @@ import {
     formatJstTime,
     getJstHour,
     getServiceLevel,
+    getServiceTraffic,
     JST_TIME_PLACEHOLDER,
     SERVICE_LEVELS,
 } from '../utils/serviceStatus';
@@ -56,5 +57,33 @@ describe('service level bands', () => {
 
     test('treats an unusable clock as out of service instead of claiming to be open', () => {
         expect(getServiceLevel(new Date('nonsense'))).toBe(SERVICE_LEVELS.closed);
+    });
+});
+
+// The background map reads its train count and speed off the same bands, so the
+// profiles have to thin out monotonically as the timetable winds down.
+describe('background traffic profiles', () => {
+    const order = ['full', 'reduced', 'last', 'closed'];
+
+    test('fewer and slower trains as service winds down', () => {
+        const trains = order.map((key) => SERVICE_LEVELS[key].traffic.trains);
+        const speeds = order.map((key) => SERVICE_LEVELS[key].traffic.speed);
+        expect(trains).toEqual([...trains].sort((a, b) => b - a));
+        expect(speeds).toEqual([...speeds].sort((a, b) => b - a));
+    });
+
+    test('only the overnight shutdown stables the fleet', () => {
+        expect(SERVICE_LEVELS.closed.traffic).toMatchObject({ trains: 0, stabled: true });
+        for (const key of ['full', 'reduced', 'last']) {
+            expect(SERVICE_LEVELS[key].traffic.stabled).toBe(false);
+            expect(SERVICE_LEVELS[key].traffic.trains).toBeGreaterThan(0);
+        }
+    });
+
+    test('reads the profile straight off the clock', () => {
+        // 13:20 JST is full service; 03:00 JST is the shutdown.
+        expect(getServiceTraffic(new Date('2026-07-25T04:20:00Z'))).toBe(SERVICE_LEVELS.full.traffic);
+        expect(getServiceTraffic(new Date('2026-07-24T18:00:00Z'))).toBe(SERVICE_LEVELS.closed.traffic);
+        expect(getServiceTraffic(new Date('nonsense'))).toBe(SERVICE_LEVELS.closed.traffic);
     });
 });

--- a/website/src/components/TransitBackground.tsx
+++ b/website/src/components/TransitBackground.tsx
@@ -1,11 +1,16 @@
 import { useMemo } from 'react';
 import { useReducedMotion } from 'motion/react';
+import useServiceLevel from '../utils/useServiceLevel';
 
 // Ambient wayfinding backdrop: a procedurally-generated transit diagram drawn
 // fresh on every page load. Coloured metro lines cross the viewport with the
 // clean 45°/90° bends of a real station map, interchange stops sit at the turns,
 // and (motion permitting) a train of light glides along each line. The whole map
 // drifts slowly. Calm on purpose — the split-flap board owns the motion budget.
+//
+// The trains run to the same Tokyo timetable as the header badge: every line is
+// worked during full service, only a couple off-peak, one on the last-train
+// band, and overnight the whole fleet is stabled at a platform until 06:00 JST.
 
 const VW = 1440;
 const VH = 900;
@@ -13,7 +18,16 @@ const GRID = 60; // lines snap to this grid, giving the map its tidy geometry
 const LINE_COLORS = ['#2ee08a', '#4aa8ff', '#ffc24b', '#b48cff']; // neon / blue / amber / purple
 
 type Pt = [number, number];
-type Line = { id: string; color: string; d: string; stations: Pt[]; dur: string; begin: string };
+type Line = {
+    id: string;
+    color: string;
+    d: string;
+    stations: Pt[];
+    dur: string;
+    begin: string;
+    depot: Pt; // where this line's train sits when it isn't running
+    rank: number; // 0 = first line to be worked, 3 = first to be taken out of service
+};
 
 const rand = (a: number, b: number) => a + Math.random() * (b - a);
 const snap = (v: number) => Math.round(v / GRID) * GRID;
@@ -85,6 +99,17 @@ function pickStations(pts: Pt[]): Pt[] {
     return out;
 }
 
+// Where an idle train waits. An interchange stop if the line has one — a stabled
+// train should read as standing at a platform — otherwise any on-screen vertex,
+// picked at random so the sleeping fleet isn't all bunched in the same place.
+function pickDepot(pts: Pt[], stations: Pt[]): Pt {
+    const pool = stations.length
+        ? stations
+        : pts.filter(([x, y]) => x > 40 && x < VW - 40 && y > 40 && y < VH - 40);
+    if (!pool.length) return pts[Math.floor(pts.length / 2)];
+    return pool[Math.floor(Math.random() * pool.length)];
+}
+
 function shuffle<T>(arr: T[]): T[] {
     const a = arr.slice();
     for (let i = a.length - 1; i > 0; i--) {
@@ -96,6 +121,8 @@ function shuffle<T>(arr: T[]): T[] {
 
 function buildMap(): Line[] {
     const orientations = shuffle(['x', 'x', 'y', 'y']);
+    // Off-peak, which lines keep their train is drawn fresh each load too.
+    const ranks = shuffle([0, 1, 2, 3]);
     let xi = 0;
     let yi = 0;
     return orientations.map((o, i) => {
@@ -105,21 +132,32 @@ function buildMap(): Line[] {
         } else {
             pts = yi++ % 2 === 0 ? buildLineY(VW * 0.12, VW * 0.44) : buildLineY(VW * 0.56, VW * 0.88);
         }
+        const stations = pickStations(pts);
         return {
             id: `tl${i}`,
             color: LINE_COLORS[i],
             d: toPath(pts),
-            stations: pickStations(pts),
+            stations,
             dur: (10 + Math.random() * 7).toFixed(2),
             begin: (-(Math.random() * 14)).toFixed(2),
+            depot: pickDepot(pts, stations),
+            rank: ranks[i],
         };
     });
 }
 
 export default function TransitBackground() {
     const prefersReduced = useReducedMotion();
-    // Generated once per mount → a different network on every page load.
+    // Generated once per mount → a different network on every page load. The
+    // timetable below only changes which trains run on it, never the map itself.
     const lines = useMemo(buildMap, []);
+    const level = useServiceLevel();
+    const { trains, speed, stabled } = level.traffic;
+
+    // Reduced-motion viewers get the same map with the fleet stood still.
+    const grounded = prefersReduced || stabled;
+    const running = grounded ? [] : lines.filter((l) => l.rank < trains);
+    const parked = grounded ? lines : [];
 
     return (
         <div
@@ -148,7 +186,7 @@ export default function TransitBackground() {
                             strokeWidth={3}
                             strokeLinejoin="round"
                             strokeLinecap="round"
-                            opacity={0.5}
+                            opacity={stabled ? 0.32 : 0.5}
                             style={{ filter: `drop-shadow(0 0 5px ${l.color})` }}
                         />
                     ))}
@@ -166,14 +204,36 @@ export default function TransitBackground() {
                             />
                         )),
                     )}
-                    {!prefersReduced &&
-                        lines.map((l) => (
-                            <circle key={`${l.id}-train`} r={4.5} fill="#ffffff" style={{ filter: `drop-shadow(0 0 6px ${l.color})` }}>
-                                <animateMotion dur={`${l.dur}s`} begin={`${l.begin}s`} repeatCount="indefinite" rotate="auto">
-                                    <mpath href={`#${l.id}`} />
-                                </animateMotion>
-                            </circle>
-                        ))}
+                    {running.map((l) => (
+                        // Keyed on the band so SMIL picks up the new duration when
+                        // the timetable changes under a long-lived tab.
+                        <circle
+                            key={`${l.id}-train-${level.key}`}
+                            r={4.5}
+                            fill="#ffffff"
+                            style={{ filter: `drop-shadow(0 0 6px ${l.color})` }}
+                        >
+                            <animateMotion
+                                dur={`${(Number(l.dur) / (speed || 1)).toFixed(2)}s`}
+                                begin={`${l.begin}s`}
+                                repeatCount="indefinite"
+                                rotate="auto"
+                            >
+                                <mpath href={`#${l.id}`} />
+                            </animateMotion>
+                        </circle>
+                    ))}
+                    {parked.map((l) => (
+                        <circle
+                            key={`${l.id}-stabled`}
+                            cx={l.depot[0]}
+                            cy={l.depot[1]}
+                            r={4}
+                            fill="#ffffff"
+                            opacity={0.4}
+                            style={{ filter: `drop-shadow(0 0 4px ${l.color})` }}
+                        />
+                    ))}
                 </g>
             </svg>
 

--- a/website/src/utils/serviceStatus.js
+++ b/website/src/utils/serviceStatus.js
@@ -39,26 +39,36 @@ export function formatJstTime(date = new Date()) {
 // Service bands read as a rail timetable: full daytime service, reduced service
 // on the shoulders either side of it, last trains late on, then the overnight
 // shutdown. `key` drives the badge styling in the header.
+//
+// `traffic` is the same timetable expressed for the background transit map, so
+// the badge and the trains behind it can never tell different stories:
+//   trains  — how many lines run a train (clamped to the lines actually drawn)
+//   speed   — multiplier on each line's own base duration; lower is slower
+//   stabled — draw the idle trains parked at a station instead of running
 export const SERVICE_LEVELS = {
     full: {
         key: 'full',
         label: 'In Service',
         detail: 'In service — full service 09:00–18:00 JST',
+        traffic: { trains: 4, speed: 1, stabled: false },
     },
     reduced: {
         key: 'reduced',
         label: 'Reduced Service',
         detail: 'Reduced service — off-peak hours in Tokyo',
+        traffic: { trains: 2, speed: 0.7, stabled: false },
     },
     last: {
         key: 'last',
         label: 'Last Train',
         detail: 'Last train — service winding down for the night in Tokyo',
+        traffic: { trains: 1, speed: 0.45, stabled: false },
     },
     closed: {
         key: 'closed',
         label: 'Out of Service',
         detail: 'Out of service — overnight shutdown, 00:00–06:00 JST',
+        traffic: { trains: 0, speed: 0, stabled: true },
     },
 };
 
@@ -70,4 +80,8 @@ export function getServiceLevel(date = new Date()) {
     if (hour < 18) return SERVICE_LEVELS.full; // 09:00–17:59
     if (hour < 22) return SERVICE_LEVELS.reduced; // 18:00–21:59
     return SERVICE_LEVELS.last; // 22:00–23:59
+}
+
+export function getServiceTraffic(date = new Date()) {
+    return getServiceLevel(date).traffic;
 }

--- a/website/src/utils/useServiceLevel.js
+++ b/website/src/utils/useServiceLevel.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+import { getServiceLevel } from './serviceStatus';
+
+// The service level only moves on the hour, so anything that just needs to know
+// which band we are in (the background map, not the header's ticking clock) can
+// poll lazily. `SERVICE_LEVELS` entries are stable singletons, so re-setting the
+// same band is a no-op re-render as far as React is concerned.
+export default function useServiceLevel(pollMs = 30000) {
+    const [level, setLevel] = useState(() => getServiceLevel());
+
+    useEffect(() => {
+        const id = setInterval(() => setLevel(getServiceLevel()), pollMs);
+        return () => clearInterval(id);
+    }, [pollMs]);
+
+    return level;
+}


### PR DESCRIPTION
## Summary
The transit background map now runs trains according to Tokyo's actual service schedule, matching the behavior of the header service status badge. Trains animate during full service hours, thin out during off-peak times, run a single train on the last-train band, and are stabled at platforms during the overnight shutdown (00:00–06:00 JST).

## Key Changes
- **Service-aware train scheduling**: Added `useServiceLevel` hook to poll the current service band and drive train visibility and animation speed
- **Timetable profiles**: Extended `SERVICE_LEVELS` with `traffic` objects defining train count, speed multiplier, and stabled state for each service band
- **Dynamic train rendering**: 
  - Running trains animate only when service is active, with speed adjusted per band (full service at 1x, reduced at 0.7x, last train at 0.45x)
  - Stabled trains render as static circles at depot locations during shutdown
  - Reduced-motion users see the fleet parked at all times
- **Depot selection**: Lines now track a `depot` location (preferring interchange stations) where idle trains wait
- **Line ranking**: Added `rank` field to determine which lines keep trains during off-peak service (randomized per page load)
- **Visual feedback**: Line opacity dims slightly during overnight shutdown to reinforce the closed state

## Implementation Details
- The map itself regenerates on every page load (different geometry each time), but the timetable only changes when crossing service band boundaries
- Train animations are keyed on the service level band to pick up duration changes when the timetable shifts under a long-lived tab
- Service level polling uses a 30-second interval since bands only change on the hour
- Comprehensive test coverage validates timetable behavior across all service bands and reduced-motion scenarios

https://claude.ai/code/session_01RBia8pBix8RErFGmYCa8ss