### PR TITLE
Improve app resilience to stale caches and storage errors

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -184,11 +184,47 @@ jobs:
           role-to-assume: ${{ secrets.AWS_S3_OIDC_ROLE }}
           role-session-name: GitHubWebsiteDeploy
 
+      # The build has two kinds of object and they want opposite caching.
+      #
+      # `assets/` is content-hashed by Vite: a given URL's bytes never change,
+      # so it can be cached forever. Everything else — above all `index.html`,
+      # which is the map from those hashes to the live build — has a stable URL
+      # and changing contents, so it has to be revalidated.
+      #
+      # Uploading with no Cache-Control at all (the previous behaviour) left
+      # browsers to guess a freshness lifetime from Last-Modified. Safari guesses
+      # generously, so it went on serving an `index.html` from before a deploy;
+      # `--delete` had already removed the hashed bundles that copy pointed at,
+      # those requests fell through to the SPA fallback and came back as HTML,
+      # and a module script served as text/html is refused outright. The result
+      # was a blank page — on whichever browser happened to be holding the stale
+      # copy, and only until its cache aged out, which is why it looked like a
+      # Safari bug. `no-cache` does not mean "don't store": the file still lives
+      # in the browser cache, it just has to be revalidated first, which is a
+      # bodyless 304 whenever nothing has changed.
       - name: Upload to S3
         env:
           AWS_S3_BUCKET: ${{ needs.build_prod.outputs.status == 'true' && secrets.AWS_S3_BUCKET_PROD }}
         run: |
-          aws s3 sync build/prod/ s3://${{ env.AWS_S3_BUCKET }}/ --delete
+          set -euo pipefail
+          BUCKET="s3://${{ env.AWS_S3_BUCKET }}/"
+
+          # Bundles first, so nothing is ever referenced before it exists.
+          aws s3 sync build/prod/ "$BUCKET" \
+            --exclude '*' --include 'assets/*' \
+            --cache-control 'public, max-age=31536000, immutable'
+
+          # Then the documents that point at them, pruning anything the build
+          # no longer produces.
+          aws s3 sync build/prod/ "$BUCKET" --delete \
+            --exclude 'assets/*' \
+            --cache-control 'no-cache'
+
+          # Finally drop the bundles this build superseded. Last, so they stay
+          # reachable for the whole window in which the old index.html was live.
+          aws s3 sync build/prod/ "$BUCKET" --delete \
+            --exclude '*' --include 'assets/*' \
+            --cache-control 'public, max-age=31536000, immutable'
 
   cypress_e2e:
     name: Cypress E2E Tests

--- a/infrastructure/modules/frontend/main.tf
+++ b/infrastructure/modules/frontend/main.tf
@@ -120,11 +120,19 @@ resource "aws_cloudfront_distribution" "crc-cf-production-distribution" {
   aliases    = [var.domain-name]
   comment    = "Production Distribution for Cloud Resume"
 
+  # Client-side routing fallback. The bucket is private behind OAC without
+  # s3:ListBucket, so a key that isn't there comes back 403 rather than 404 —
+  # that 403 is what every deep link (`/skills`, `/projects`) hits, and it has
+  # to resolve to the app shell for the router to take over.
+  #
+  # It resolves as 200: these are real pages, and answering them 400 told
+  # crawlers, link previewers and anything else reading the status line that
+  # the site was rejecting its own URLs.
   custom_error_response {
     error_caching_min_ttl = "10"
     error_code            = "403"
-    response_code         = "400"
-    response_page_path    = "/"
+    response_code         = "200"
+    response_page_path    = "/index.html"
   }
 
   default_cache_behavior {

--- a/website/index.html
+++ b/website/index.html
@@ -11,6 +11,103 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
     <title>Cloud Resume</title>
+
+    <!--
+      Boot recovery net.
+
+      This document is the map from content hashes to the live build, so a copy
+      of it that outlives its deploy points at bundles that no longer exist.
+      Those requests fall through to the SPA error-page rule and come back as
+      HTML; a module script served as text/html is refused outright, nothing
+      mounts, and the visitor sits looking at a blank page with no way out but
+      clearing their browser data. Safari is where this actually bites, because
+      it is the most willing of the major browsers to reuse a cached document
+      without revalidating it.
+
+      The deploy now sends `Cache-Control: no-cache` for this file, which is the
+      real fix. This is the belt to that pair of braces: if the page fails to
+      boot anyway, refetch the document past the cache once and reload. Inline
+      and classic (not a module) so it runs even when the module graph is the
+      thing that is broken.
+    -->
+    <script>
+      (function () {
+          var KEY = 'crc:boot-recovered';
+          var done = false;
+
+          // One attempt per tab. sessionStorage is the durable marker, but it
+          // throws outright when the visitor has blocked cookies, so fall back
+          // to "are we already inside a reload?" — enough to stop a loop.
+          try {
+              done = sessionStorage.getItem(KEY) === '1';
+          } catch (e) {
+              var nav = (performance.getEntriesByType &&
+                  performance.getEntriesByType('navigation')[0]) || null;
+              done = nav ? nav.type === 'reload' : false;
+          }
+
+          function recover(reason) {
+              if (done) return;
+              done = true;
+              try {
+                  sessionStorage.setItem(KEY, '1');
+              } catch (e) {
+                  /* blocked storage — the navigation-type check above covers us */
+              }
+              console.warn('[boot] app failed to start (' + reason + '); refetching past the cache');
+              // `cache: 'reload'` bypasses the cached copy and replaces the
+              // stored entry, so the reload that follows gets the live document
+              // with the live asset hashes in it.
+              var refetch = window.fetch
+                  ? fetch(location.href, { cache: 'reload', credentials: 'same-origin' })
+                  : Promise.resolve();
+              refetch.catch(function () {}).then(function () {
+                  location.reload();
+              });
+          }
+
+          // A bundle that 404s, or comes back as the HTML fallback page and is
+          // refused on MIME grounds, fires an error event at its element. These
+          // don't bubble, hence the capture phase.
+          //
+          // Only our own files count. The web font stylesheet is cross-origin
+          // and blocked often enough — content blockers, captive portals — that
+          // treating it as evidence of a stale build would mean reloading the
+          // page on people whose only problem is that the fonts didn't arrive.
+          function isOurs(el) {
+              var url = el.src || el.href;
+              if (!url) return false;
+              try {
+                  return new URL(url, location.href).origin === location.origin;
+              } catch (e) {
+                  return false;
+              }
+          }
+
+          window.addEventListener(
+              'error',
+              function (event) {
+                  var el = event.target;
+                  if (!el || el === window || !isOurs(el)) return;
+                  if (el.tagName === 'SCRIPT') recover('script failed to load');
+                  else if (el.tagName === 'LINK' && el.rel === 'stylesheet') {
+                      recover('stylesheet failed to load');
+                  }
+              },
+              true,
+          );
+
+          // Backstop for failure modes that never fire a resource error — a
+          // bundle that parses but throws on evaluation, say. If nothing has
+          // mounted well after load, treat the page as dead.
+          window.addEventListener('load', function () {
+              setTimeout(function () {
+                  var root = document.getElementById('root');
+                  if (root && root.childElementCount === 0) recover('nothing mounted');
+              }, 10000);
+          });
+      })();
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -50,32 +50,38 @@ function AnimatedRoutes() {
 
 export default function App() {
     return (
-        <MotionConfig reducedMotion='user'>
-            <TransitBackground />
-            <StationHeader />
-            <a
-                href='#content'
-                className='sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-14 focus:z-50 focus:rounded focus:bg-primary-500 focus:px-4 focus:py-2 focus:text-secondary-900'
-            >
-                Skip to main content
-            </a>
-            <BrowserRouter>
-                <NoticeBanner />
-                {/* Below `sm` the rail map collapses to a horizontal strip above the
-                    board; from `sm` up it returns to the left-hand line map. */}
-                <div className='mx-auto flex max-w-6xl flex-col items-stretch px-3 max-sm:pt-16 sm:flex-row sm:items-start sm:justify-center sm:px-0'>
-                    <Navigation />
-                    <div className='sm:min-w-102 w-full max-w-2xl space-y-8 max-sm:mx-auto max-sm:pb-12 max-sm:pt-6 sm:w-3/5 sm:px-2 sm:py-20'>
-                        <ErrorBoundary>
-                            <Suspense fallback={<LoadingSkeleton />}>
-                                <main id='content' tabIndex={-1} className='outline-none'>
-                                    <AnimatedRoutes />
-                                </main>
-                            </Suspense>
-                        </ErrorBoundary>
+        // The outer boundary covers the chrome — background, header, nav — which
+        // the inner one around the routes does not. Anything that throws out
+        // there used to unmount the entire tree and leave a blank document; now
+        // the worst case is a page that says so and offers a way back.
+        <ErrorBoundary>
+            <MotionConfig reducedMotion='user'>
+                <TransitBackground />
+                <StationHeader />
+                <a
+                    href='#content'
+                    className='sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-14 focus:z-50 focus:rounded focus:bg-primary-500 focus:px-4 focus:py-2 focus:text-secondary-900'
+                >
+                    Skip to main content
+                </a>
+                <BrowserRouter>
+                    <NoticeBanner />
+                    {/* Below `sm` the rail map collapses to a horizontal strip above the
+                        board; from `sm` up it returns to the left-hand line map. */}
+                    <div className='mx-auto flex max-w-6xl flex-col items-stretch px-3 max-sm:pt-16 sm:flex-row sm:items-start sm:justify-center sm:px-0'>
+                        <Navigation />
+                        <div className='sm:min-w-102 w-full max-w-2xl space-y-8 max-sm:mx-auto max-sm:pb-12 max-sm:pt-6 sm:w-3/5 sm:px-2 sm:py-20'>
+                            <ErrorBoundary>
+                                <Suspense fallback={<LoadingSkeleton />}>
+                                    <main id='content' tabIndex={-1} className='outline-none'>
+                                        <AnimatedRoutes />
+                                    </main>
+                                </Suspense>
+                            </ErrorBoundary>
+                        </div>
                     </div>
-                </div>
-            </BrowserRouter>
-        </MotionConfig>
+                </BrowserRouter>
+            </MotionConfig>
+        </ErrorBoundary>
     );
 }

--- a/website/src/__tests__/useVisitorId.test.js
+++ b/website/src/__tests__/useVisitorId.test.js
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react';
+import { useVisitorId } from '../utils/useVisitorId';
+
+// iOS Safari with "Block All Cookies" throws on any access to `localStorage`,
+// not just on write. The hook renders inside the nav bar, so a throw here used
+// to unmount the whole app — the site came up blank on that one browser.
+function withLocalStorage(impl) {
+    const original = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, ...impl });
+    return () => {
+        if (original) Object.defineProperty(globalThis, 'localStorage', original);
+        else delete globalThis.localStorage;
+    };
+}
+
+describe('useVisitorId', () => {
+    let restore;
+
+    afterEach(() => {
+        restore?.();
+        restore = undefined;
+    });
+
+    it('reuses a previously stored id', () => {
+        restore = withLocalStorage({
+            value: { getItem: () => 'stored-id', setItem: vi.fn() },
+        });
+        const { result } = renderHook(() => useVisitorId());
+        expect(result.current).toBe('stored-id');
+    });
+
+    it('generates and persists an id when none is stored', () => {
+        const setItem = vi.fn();
+        restore = withLocalStorage({ value: { getItem: () => null, setItem } });
+
+        const { result } = renderHook(() => useVisitorId());
+
+        expect(result.current).toBeTruthy();
+        expect(setItem).toHaveBeenCalledWith('uuid', result.current);
+    });
+
+    it('still yields an id when storage access throws', () => {
+        restore = withLocalStorage({
+            get() {
+                throw new DOMException('The operation is insecure.', 'SecurityError');
+            },
+        });
+
+        const { result } = renderHook(() => useVisitorId());
+
+        expect(typeof result.current).toBe('string');
+        expect(result.current.length).toBeGreaterThan(0);
+    });
+
+    it('still yields an id when writing to storage throws', () => {
+        restore = withLocalStorage({
+            value: {
+                getItem: () => null,
+                setItem: () => {
+                    throw new DOMException('exceeded the quota.', 'QuotaExceededError');
+                },
+            },
+        });
+
+        const { result } = renderHook(() => useVisitorId());
+
+        expect(typeof result.current).toBe('string');
+        expect(result.current.length).toBeGreaterThan(0);
+    });
+
+    it('falls back to a random id when crypto.randomUUID is unavailable', () => {
+        restore = withLocalStorage({ value: { getItem: () => null, setItem: vi.fn() } });
+        const randomUUID = globalThis.crypto?.randomUUID;
+        if (randomUUID) globalThis.crypto.randomUUID = undefined;
+
+        try {
+            const { result } = renderHook(() => useVisitorId());
+            expect(result.current).toMatch(/^anon-/);
+        } finally {
+            if (randomUUID) globalThis.crypto.randomUUID = randomUUID;
+        }
+    });
+});

--- a/website/src/utils/useVisitorId.js
+++ b/website/src/utils/useVisitorId.js
@@ -1,14 +1,52 @@
 // website/src/utils/useVisitorId.js
 import { useState } from 'react';
 
+const STORAGE_KEY = 'uuid';
+
+// Web Storage is not always reachable. iOS Safari with "Block All Cookies" set
+// throws a SecurityError on the very first property access — not on read, on
+// touching `localStorage` at all — and older WebKit throws QuotaExceededError
+// when writing in a private tab. This hook runs inside the nav bar, which sits
+// outside the ErrorBoundary, so an unguarded throw here took the whole app down
+// to a blank page for anyone with that setting on.
+//
+// A visitor with storage blocked simply counts as new on every visit, which is
+// the correct outcome for someone who has asked not to be persisted anyway.
+function readStoredId() {
+    try {
+        return localStorage.getItem(STORAGE_KEY);
+    } catch {
+        return null;
+    }
+}
+
+function storeId(value) {
+    try {
+        localStorage.setItem(STORAGE_KEY, value);
+    } catch {
+        /* storage unavailable — the id stays good for this page view only */
+    }
+}
+
+// `crypto.randomUUID` needs a secure context and Safari 15.4+; fall back to a
+// plain random id rather than throwing, since this value only has to be unique
+// enough to deduplicate a visit.
+function newId() {
+    try {
+        if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+    } catch {
+        /* fall through */
+    }
+    return `anon-${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
 export function useVisitorId() {
     const [id] = useState(() => {
-        let v = localStorage.getItem('uuid');
-        if (!v) {
-            v = crypto.randomUUID();
-            localStorage.setItem('uuid', v);
-        }
-        return v;
+        const stored = readStoredId();
+        if (stored) return stored;
+        const created = newId();
+        storeId(created);
+        return created;
     });
     return id;
 }


### PR DESCRIPTION
## Summary
This PR hardens the Cloud Resume application against common failure modes related to browser caching and storage access restrictions. It adds recovery mechanisms for stale cached assets, improves error handling for restricted storage access, and fixes CloudFront configuration to properly serve the SPA fallback.

## Key Changes

- **Boot recovery script** (`index.html`): Added an inline recovery mechanism that detects when the app fails to load (missing bundles, stylesheet failures, or nothing mounting after 10 seconds) and refetches the index.html past the cache to get fresh asset hashes. This prevents blank pages when Safari or other browsers serve stale cached versions after a deploy.

- **Storage access hardening** (`useVisitorId.js`): Wrapped all localStorage access in try-catch blocks to gracefully handle SecurityError (iOS Safari with "Block All Cookies") and QuotaExceededError (private browsing). Falls back to a random anonymous ID when storage is unavailable, and implements a fallback UUID generation method for older browsers without `crypto.randomUUID`.

- **Comprehensive test coverage** (`useVisitorId.test.js`): Added tests covering all storage failure scenarios including blocked access, quota exceeded, and missing crypto API.

- **Error boundary expansion** (`App.js`): Wrapped the entire app (including chrome like header and navigation) in an outer ErrorBoundary to prevent blank pages when errors occur in components outside the route-specific boundary.

- **S3 upload strategy** (`.github/workflows/website.yml`): Implemented three-phase upload with proper Cache-Control headers:
  - Assets (content-hashed) uploaded with `max-age=31536000, immutable`
  - Documents (index.html, etc.) uploaded with `no-cache` for revalidation
  - Old assets cleaned up last to maintain availability during transition

- **CloudFront configuration** (`infrastructure/modules/frontend/main.tf`): Fixed 403 error handling to return 200 status with `/index.html` content instead of 400, allowing the SPA router to handle deep links properly while maintaining correct HTTP semantics for crawlers and link previewers.

## Implementation Details

The boot recovery script uses sessionStorage (with fallback to navigation type detection) to ensure only one recovery attempt per tab, preventing infinite reload loops. The storage access improvements follow a defensive pattern: try the operation, catch any exception, and provide a sensible fallback that doesn't break the app.

The S3 upload strategy ensures bundles exist before documents reference them, and cleans up old bundles last to maintain availability during the transition window.

https://claude.ai/code/session_01ShjwLFHaNWS8teF2KFzbWZ