### PR TITLE
Make concourse board status reflect Tokyo timetable

### DIFF
--- a/website/src/__tests__/Home.test.js
+++ b/website/src/__tests__/Home.test.js
@@ -19,6 +19,10 @@ vi.mock('../components/social_links', () => ({ default: () => null }));
 vi.mock('../components/personal_summary', () => ({ default: () => null }));
 
 describe('Home component', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('renders profile data correctly', () => {
         render(<Home />);
         // Profile photo with descriptive alt
@@ -33,5 +37,19 @@ describe('Home component', () => {
         // Availability tag from JSON (no salary)
         expect(screen.getByText('Available for consulting')).toBeInTheDocument();
         expect(screen.queryByText(/salary/i)).not.toBeInTheDocument();
+    });
+
+    // The board header's status pill is a live service claim, not decoration.
+    it('reports the concourse board status from the Tokyo timetable', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-25T04:20:00Z')); // 13:20 JST
+        const { unmount } = render(<Home />);
+        expect(screen.getByText('All Lines Running')).toBeInTheDocument();
+        unmount();
+
+        vi.setSystemTime(new Date('2026-07-25T18:00:00Z')); // 03:00 JST
+        render(<Home />);
+        expect(screen.getByText('Lines Closed')).toBeInTheDocument();
+        expect(screen.queryByText('All Lines Running')).not.toBeInTheDocument();
     });
 });

--- a/website/src/__tests__/ServiceStatusPill.test.js
+++ b/website/src/__tests__/ServiceStatusPill.test.js
@@ -1,0 +1,58 @@
+import { act, render, screen } from '@testing-library/react';
+import ServiceStatusPill from '../components/service_status_pill';
+
+// The concourse pill is a service claim, so it has to follow the Tokyo
+// timetable rather than assert "All Lines Running" around the clock.
+describe('ServiceStatusPill', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const renderAt = (iso) => {
+        vi.setSystemTime(new Date(iso));
+        return render(<ServiceStatusPill />);
+    };
+
+    test('claims every line is running only during full service', () => {
+        renderAt('2026-07-25T04:20:00Z'); // 13:20 JST
+        expect(screen.getByText('All Lines Running')).toBeInTheDocument();
+    });
+
+    test('reads Reduced Service on the shoulders of the Tokyo day', () => {
+        renderAt('2026-07-24T22:30:00Z'); // 07:30 JST
+        expect(screen.getByText('Reduced Service')).toBeInTheDocument();
+        expect(screen.queryByText('All Lines Running')).not.toBeInTheDocument();
+    });
+
+    test('reads Last Trains Running late in the Tokyo evening', () => {
+        renderAt('2026-07-25T13:30:00Z'); // 22:30 JST
+        expect(screen.getByText('Last Trains Running')).toBeInTheDocument();
+    });
+
+    test('reads Lines Closed during the overnight shutdown, with no live signal', () => {
+        const { container } = renderAt('2026-07-25T18:00:00Z'); // 03:00 JST
+        expect(screen.getByText('Lines Closed')).toBeInTheDocument();
+        // Nothing is running, so nothing pulses.
+        expect(container.querySelector('.animate-pulse')).toBeNull();
+    });
+
+    test('carries the band detail as a tooltip', () => {
+        renderAt('2026-07-25T18:00:00Z'); // 03:00 JST
+        expect(screen.getByText('Lines Closed')).toHaveAttribute(
+            'title',
+            expect.stringContaining('overnight shutdown'),
+        );
+    });
+
+    test('flips when the clock crosses a band boundary under a long-lived tab', () => {
+        renderAt('2026-07-25T08:59:00Z'); // 17:59 JST
+        expect(screen.getByText('All Lines Running')).toBeInTheDocument();
+        vi.setSystemTime(new Date('2026-07-25T09:00:30Z')); // 18:00 JST
+        act(() => vi.advanceTimersByTime(30000)); // one poll of useServiceLevel
+        expect(screen.getByText('Reduced Service')).toBeInTheDocument();
+    });
+});

--- a/website/src/__tests__/serviceStatus.test.js
+++ b/website/src/__tests__/serviceStatus.test.js
@@ -58,6 +58,15 @@ describe('service level bands', () => {
     test('treats an unusable clock as out of service instead of claiming to be open', () => {
         expect(getServiceLevel(new Date('nonsense'))).toBe(SERVICE_LEVELS.closed);
     });
+
+    // Every band needs its own board wording — a shared string would let the
+    // concourse pill keep reading "All Lines Running" after the last train.
+    test('gives every band its own board wording', () => {
+        const boards = Object.values(SERVICE_LEVELS).map((level) => level.board);
+        expect(boards.every(Boolean)).toBe(true);
+        expect(new Set(boards).size).toBe(boards.length);
+        expect(SERVICE_LEVELS.full.board).toBe('All Lines Running');
+    });
 });
 
 // The background map reads its train count and speed off the same bands, so the

--- a/website/src/components/service_status_pill.jsx
+++ b/website/src/components/service_status_pill.jsx
@@ -1,0 +1,24 @@
+import { StatusPill } from './ui/primitives';
+import useServiceLevel from '../utils/useServiceLevel';
+
+// The concourse board's status pill. It used to be hard-coded to "All Lines
+// Running", which contradicted the header badge and the stabled trains on the
+// background map whenever Tokyo was off-peak or shut for the night. It now reads
+// off the same JST timetable as both, so the whole page tells one story.
+
+// Signal colour per band, matching the header badge.
+const LEVEL_TONES = {
+    full: 'on',
+    reduced: 'reduced',
+    last: 'alert',
+    closed: 'past',
+};
+
+export default function ServiceStatusPill() {
+    const level = useServiceLevel();
+    return (
+        <StatusPill tone={LEVEL_TONES[level.key] ?? 'on'} title={level.detail}>
+            {level.board}
+        </StatusPill>
+    );
+}

--- a/website/src/components/ui/primitives.tsx
+++ b/website/src/components/ui/primitives.tsx
@@ -50,23 +50,32 @@ export function LineBadge({
     );
 }
 
-// Status pill — service state (on-time / departed / suspended).
+// Status pill — service state (on-time / reduced / departed / suspended). The
+// signal colours match the header badge: green go, amber off-peak, red late,
+// grey and unlit once nothing is running.
+const PILL_TONES = {
+    on: { text: 'text-neon', dot: 'h-1.5 w-1.5 animate-pulse rounded-full bg-neon' },
+    reduced: { text: 'text-glow', dot: 'h-1.5 w-1.5 animate-pulse rounded-full bg-glow' },
+    past: { text: 'text-content-date', dot: null },
+    alert: { text: 'text-alert', dot: 'h-1.5 w-1.5 rounded-full bg-alert' },
+} as const;
+
 export function StatusPill({
     tone = 'on',
+    title,
     children,
 }: {
-    tone?: 'on' | 'past' | 'alert';
+    tone?: keyof typeof PILL_TONES;
+    title?: string;
     children: ReactNode;
 }) {
-    const styles = {
-        on: 'text-neon',
-        past: 'text-content-date',
-        alert: 'text-alert',
-    }[tone];
+    const { text, dot } = PILL_TONES[tone] ?? PILL_TONES.on;
     return (
-        <span className={cn('inline-flex items-center gap-1.5 font-mono text-[0.62rem] font-semibold uppercase tracking-[0.14em]', styles)}>
-            {tone === 'on' && <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neon" />}
-            {tone === 'alert' && <span className="h-1.5 w-1.5 rounded-full bg-alert" />}
+        <span
+            title={title}
+            className={cn('inline-flex items-center gap-1.5 font-mono text-[0.62rem] font-semibold uppercase tracking-[0.14em]', text)}
+        >
+            {dot && <span className={dot} />}
             {children}
         </span>
     );

--- a/website/src/pages/Home/index.jsx
+++ b/website/src/pages/Home/index.jsx
@@ -1,7 +1,8 @@
 import PersonalSummary from '../../components/personal_summary';
+import ServiceStatusPill from '../../components/service_status_pill';
 import SocialLinks from '../../components/social_links';
 import SplitFlap from '../../components/split_flap';
-import { SectionShell, Chip, StatusPill } from '../../components/ui/primitives';
+import { SectionShell, Chip } from '../../components/ui/primitives';
 import { useJsonData, LoadingSkeleton } from '../../utils/useJsonData';
 
 function Home() {
@@ -18,7 +19,9 @@ function Home() {
                 // The concourse label is board chrome; the page's h1 is the name below.
                 titleAs='p'
                 line={0}
-                right={<StatusPill tone='on'>All Lines Running</StatusPill>}
+                // The board status follows the Tokyo timetable, same as the
+                // header badge and the trains on the background map.
+                right={<ServiceStatusPill />}
             >
                 <div className='flex flex-col gap-6 sm:flex-row sm:items-start'>
                     {/* ID pass card */}

--- a/website/src/utils/serviceStatus.js
+++ b/website/src/utils/serviceStatus.js
@@ -40,6 +40,10 @@ export function formatJstTime(date = new Date()) {
 // on the shoulders either side of it, last trains late on, then the overnight
 // shutdown. `key` drives the badge styling in the header.
 //
+// `label` is the header badge's wording; `board` is the same state phrased for a
+// platform board's status pill, which talks about lines rather than the network.
+// Only full service can honestly claim every line is running.
+//
 // `traffic` is the same timetable expressed for the background transit map, so
 // the badge and the trains behind it can never tell different stories:
 //   trains  — how many lines run a train (clamped to the lines actually drawn)
@@ -49,24 +53,28 @@ export const SERVICE_LEVELS = {
     full: {
         key: 'full',
         label: 'In Service',
+        board: 'All Lines Running',
         detail: 'In service — full service 09:00–18:00 JST',
         traffic: { trains: 4, speed: 1, stabled: false },
     },
     reduced: {
         key: 'reduced',
         label: 'Reduced Service',
+        board: 'Reduced Service',
         detail: 'Reduced service — off-peak hours in Tokyo',
         traffic: { trains: 2, speed: 0.7, stabled: false },
     },
     last: {
         key: 'last',
         label: 'Last Train',
+        board: 'Last Trains Running',
         detail: 'Last train — service winding down for the night in Tokyo',
         traffic: { trains: 1, speed: 0.45, stabled: false },
     },
     closed: {
         key: 'closed',
         label: 'Out of Service',
+        board: 'Lines Closed',
         detail: 'Out of service — overnight shutdown, 00:00–06:00 JST',
         traffic: { trains: 0, speed: 0, stabled: true },
     },


### PR DESCRIPTION
## Summary
The concourse board's status pill was hard-coded to "All Lines Running" regardless of the time of day, which contradicted the header badge and background train map that both follow Tokyo's service timetable. This change makes the status pill dynamic, reading from the same JST-based service level system used elsewhere on the page.

## Key Changes
- **New `ServiceStatusPill` component** (`service_status_pill.jsx`): Replaces the hard-coded status pill with a dynamic component that reads the current service level and displays appropriate messaging for each band (full service, reduced, last trains, closed)
- **Extended `StatusPill` primitive** (`primitives.tsx`): 
  - Added support for a `reduced` tone (amber, matching off-peak styling)
  - Added optional `title` prop for tooltips
  - Refactored tone styling into a `PILL_TONES` constant for consistency
  - Added pulsing animation for the `reduced` tone to match the `on` state
- **Enhanced `SERVICE_LEVELS` data** (`serviceStatus.js`): Added `board` field to each service level with distinct wording for the platform board context (e.g., "Lines Closed" instead of "Out of Service")
- **Updated Home page** (`Home/index.jsx`): Replaced hard-coded `StatusPill` with the new `ServiceStatusPill` component
- **Comprehensive test coverage**:
  - New `ServiceStatusPill.test.js` with 6 tests covering all service bands, tooltips, and dynamic updates
  - Updated `Home.test.js` to verify the board status reflects the Tokyo timetable
  - New validation in `serviceStatus.test.js` ensuring each band has unique board wording

## Implementation Details
- The component uses the existing `useServiceLevel()` hook to determine the current service state
- Signal colours match the header badge: green (full), amber (reduced), red (last trains), grey (closed)
- The pulsing animation only appears when service is active, providing visual feedback that matches the semantic meaning
- All four service bands now have distinct board messaging to prevent the pill from incorrectly claiming "All Lines Running" during off-peak or closed periods

https://claude.ai/code/session_01RsG2fpSjNxSoMsEmQS2YHE