### PR TITLE
fix(cache): invalidate the CDN's copy of / and stop deleting live bundles

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,6 +10,10 @@ on:
       - 'main'
     paths:
       - 'website/**'
+  # A deploy re-uploads index.html, which is what kicks the invalidation
+  # Lambda; without this there is no way to refresh the CDN's cached
+  # document short of committing a website change.
+  workflow_dispatch:
 
 permissions: {}
 
@@ -220,11 +224,33 @@ jobs:
             --exclude 'assets/*' \
             --cache-control 'no-cache'
 
-          # Finally drop the bundles this build superseded. Last, so they stay
-          # reachable for the whole window in which the old index.html was live.
-          aws s3 sync build/prod/ "$BUCKET" --delete \
-            --exclude '*' --include 'assets/*' \
-            --cache-control 'public, max-age=31536000, immutable'
+          # Superseded bundles are NOT deleted in the same run. A cached copy
+          # of index.html keeps pointing at the bundles of its own build for
+          # as long as any cache holds it — CloudFront held the document under
+          # "/" for up to a day, and browser copies from before Cache-Control
+          # was sent age out on heuristic lifetimes measured in days — so
+          # bundles have to outlive documents by that margin, not by the
+          # seconds a same-run delete gave them. Every sync above refreshes
+          # LastModified on the objects the current build ships (fresh CI
+          # mtimes force re-upload), so anything under assets/ still carrying
+          # a 60-day-old timestamp has been out of every deployed index.html
+          # for two months. Prune those; visitors on documents older than that
+          # are caught by the boot recovery net in index.html.
+          CUTOFF=$(date -u -d '60 days ago' +%s)
+          aws s3api list-objects-v2 \
+            --bucket "$AWS_S3_BUCKET" --prefix 'assets/' --output json |
+            jq -r --argjson cutoff "$CUTOFF" '
+              .Contents // [] | .[]
+              | select((.LastModified
+                  | sub("\\.[0-9]+"; "") | sub("\\+00:00$"; "Z")
+                  | fromdate) < $cutoff)
+              | .Key' |
+            while IFS= read -r key; do
+              # Belt to the timestamp braces: never drop a file the current
+              # build actually shipped.
+              [ -e "build/prod/$key" ] && continue
+              aws s3 rm "${BUCKET}${key}"
+            done
 
   cypress_e2e:
     name: Cypress E2E Tests

--- a/infrastructure/codebase/cloudfrontInvalidation.py
+++ b/infrastructure/codebase/cloudfrontInvalidation.py
@@ -34,6 +34,16 @@ def lambda_handler(event, context):
             # Determine the distribution ID based on the bucket name
             if bucket_name == prodBucket:
                 invalidation_paths[prodDistribution].append(path)
+                # CloudFront caches by request URI, and visitors request "/",
+                # not "/index.html" — default_root_object rewrites the origin
+                # fetch but not the cache key. Invalidating only the object key
+                # leaves the copy cached under the bare URL untouched, so it
+                # kept serving a pre-deploy document (pointing at deleted
+                # bundles) until its TTL ran out. Same for any nested index.
+                if object_key == "index.html" or object_key.endswith("/index.html"):
+                    invalidation_paths[prodDistribution].append(
+                        path[: -len("index.html")]
+                    )
             else:
                 print(f"Bucket {bucket_name} is not configured for cache invalidation.")
                 continue
@@ -49,6 +59,7 @@ def lambda_handler(event, context):
 
     # Create invalidations in batches
     for distribution_id, paths in invalidation_paths.items():
+        paths = list(dict.fromkeys(paths))  # dedupe, keep order
         if paths:
             try:
                 invalidation = client.create_invalidation(


### PR DESCRIPTION
PR #113 fixed the browser layer of the stale-document problem and missed
the CDN layer sitting in front of it, which is why it read as a
regression: CloudFront had cached the pre-deploy index.html under the
cache key "/" (visitors request the bare URL; default_root_object
rewrites the origin fetch, not the cache key), that copy predated
Cache-Control being sent so CachingOptimized held it for its 24h default
TTL, and the invalidation Lambda only ever invalidated literal object
keys like /index.html — never "/". The deploy then deleted the bundles
that stale document pointed at, and the boot recovery script could not
help: its cache:'reload' refetch busts the browser cache but CloudFront
ignores request Cache-Control, so the one permitted reload fetched the
same stale document and left the page dead — the flat background ~10s
after load is the recovery net's nothing-mounted timer firing and
burning its single attempt.

Three changes:

- cloudfrontInvalidation.py now also invalidates the bare-URL form
  whenever an index.html is uploaded, so the copy cached under "/"
  (and any nested index) is purged on every deploy. Paths are deduped
  before the batch is created.

- The deploy no longer deletes superseded bundles in the same run —
  that gave them a grace window of seconds when cached documents need
  days. Bundles are pruned only once their LastModified is 60 days old;
  every deploy re-uploads what it ships (fresh CI mtimes), so that age
  means no deployed document has referenced them for two months. A
  local-file existence check backstops the timestamp logic.

- website.yml gains workflow_dispatch: re-uploading index.html is what
  triggers invalidation, and there was previously no way to do that
  without committing a website change.

No code change can purge the stale copy CloudFront is serving right
now; run a one-off invalidation for "/*" (or trigger a deploy once
this merges) to clear it immediately rather than waiting out the TTL.

Co-Authored-By: Claude <noreply@anthropic.com>