### PR TITLE
fix(cv): drop the reserved concurrency the account cannot grant

### DIFF
--- a/docs/signed-downloads.md
+++ b/docs/signed-downloads.md
@@ -243,6 +243,23 @@ anchor is dead in that gap.
   that region. Writing the SecureString creates it, so the bootstrap covers this; but note it
   surfaces *after* the parameter read, so a region mistake produces two failures in sequence
   rather than one.
+- `InvalidParameterValueException: Specified ReservedConcurrentExecutions ... below its minimum
+  value of [10]` — this account's total Lambda concurrency limit is 10, and AWS refuses any
+  reservation that would leave less than 10 unreserved, so no per-function reservation is
+  possible at all. `downloadResume` therefore runs unreserved like every other function here.
+  The stage throttle is the real bound; see below.
+
+## Concurrency
+
+The account ceiling is 10 concurrent executions across every function, which is itself a hard
+bound on what `/download` can cost. What is missing is *isolation*: without a per-function
+reservation, a burst on `/download` can consume the whole pool and starve `trackVisitors` and
+`sendMessage`. The stage throttle (2 rps / 5 burst on `download/GET`) is what prevents that,
+by capping issuance before a request ever reaches Lambda.
+
+If the account's concurrency quota is raised, reinstating
+`reserved_concurrent_executions` on `crc-downloadResume` is worth doing — the comment on that
+resource says so.
 
 ## Operations
 

--- a/infrastructure/modules/backend/main.tf
+++ b/infrastructure/modules/backend/main.tf
@@ -476,10 +476,21 @@ resource "aws_lambda_function" "crc-downloadResume" {
 
   source_code_hash = data.archive_file.downloadResume_lambda_function_code.output_base64sha256
 
-  # Bounded rather than unreserved, unlike the other functions. This is the only endpoint
-  # that mints credentials for a paid egress path, so it is also the one worth capping at
-  # the function as well as at the stage.
-  reserved_concurrent_executions = "5"
+  # Unreserved, like every other function here. A per-function reservation was the intent —
+  # this is the only endpoint that mints credentials for a paid egress path — but it is not
+  # available on this account: PutFunctionConcurrency refuses any reservation that would
+  # drop UnreservedConcurrentExecution below 10, and the account's total concurrency limit
+  # *is* 10. So reserving anything at all is rejected until that quota is raised.
+  #
+  # Losing it costs less than it appears. A 10-execution account ceiling is itself a hard
+  # bound, and the real control was always the stage throttle in modules/frontend
+  # (2 rps / 5 burst on download/GET), which caps issuance before a request reaches Lambda.
+  #
+  # What is genuinely given up is isolation: a burst on /download can now consume the
+  # account's whole concurrency pool and starve trackVisitors and sendMessage. The stage
+  # throttle is what keeps that from happening. If the account limit is ever raised, this
+  # is worth reinstating.
+  reserved_concurrent_executions = "-1"
 
   role = var.iam-role-download-issuer-arn
 


### PR DESCRIPTION
Follow-up to #119. The post-merge apply failed partway, leaving the Download CV link broken in production. This completes it.

## The failure

```
Error: setting Lambda Function (downloadResume) concurrency: ...
InvalidParameterValueException: Specified ReservedConcurrentExecutions for function
decreases account's UnreservedConcurrentExecution below its minimum value of [10].
```

This account's **total** Lambda concurrency limit is 10, and AWS refuses any reservation that would leave fewer than 10 unreserved. So it is not that `5` was too high — no reservation of any size is possible here. `reserved_concurrent_executions` goes to `-1`, matching the other four functions.

## What that gives up, and why it is acceptable

Less than it looks. A 10-execution account ceiling is itself a hard bound, and the control that actually matters was always the stage throttle added in #119: **2 rps / 5 burst on `download/GET`**, which caps issuance before a request reaches Lambda at all.

What is genuinely lost is *isolation* — a burst on `/download` can now consume the whole pool and starve `trackVisitors` and `sendMessage`. The stage throttle is what prevents that. Both the resource comment and `docs/signed-downloads.md` record that this is worth reinstating if the account quota is ever raised, and the error is now listed among the documented failure modes.

## Production state while this is unmerged

The apply got further than the error suggests. In order:

```
aws_cloudfront_distribution: Modifications complete after 48s
aws_s3_bucket_policy:        Modifications complete after 0s
Error: setting Lambda Function (downloadResume) concurrency...
```

Both landed **before** the failure, so `s3:ListBucket` is granted and the `404` fallback matches it — **deep links are healthy** and that transition window closed cleanly.

The single breakage: `/files/*` is gated, but `web-deploy` is gated on the `terraform` job and was skipped, so the live site still serves the previous bundle whose Download CV anchor points at the now-gated plain path. That one link returns 403. Routing, the visitor counter and the contact form are unaffected.

Merging completes the apply and lets `web-deploy` ship the bundle that calls `/download`, which is what restores the button.

## Expected in the plan

`downloadResume` will show as **replaced**, not created. The function was created successfully and only the subsequent `PutFunctionConcurrency` call failed, so Terraform recorded it tainted. That is correct, not a second problem.

`web-smoke` will run `cv-download-live.cy.js` for the first time — it clicks the live button, has the Lambda mint a signed URL from the SSM key, and fetches it. A 200 with `application/pdf` is the first end-to-end proof that both halves of the key pair agree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb3x62UmRMuojEg98o7rMb)_