### PR TITLE
fix(ci): stop the production smoke test skipping on every manual deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -922,9 +922,17 @@ jobs:
     # Also runs after a manual deploy — the CDN-invalidation escape hatch is a
     # real deploy and deserves the same check. Skipped for a dry run, which by
     # definition changed nothing.
+    #
+    # `inputs.dry_run == true`, not a bare `inputs.dry_run`. A workflow_dispatch
+    # input arrives as the *string* "false" when the box is left unticked, and a
+    # non-empty string is truthy in a GitHub expression — so the bare form read
+    # every manual run as a dry run and skipped this job. A skipped job counts as
+    # a pass in ci-ok, so the whole point of the job (see above) was silently
+    # lost on exactly the runs that deploy without a website commit behind them.
+    # The `== true` comparison coerces properly; lines 620 and 624 already do it.
     if: >-
       ${{ needs.web-deploy.result == 'success'
-          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
     permissions:
       contents: read
     defaults:


### PR DESCRIPTION
## The bug

`web-smoke` gated on a bare `inputs.dry_run`:

```yaml
if: >-
  ${{ needs.web-deploy.result == 'success'
      && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
```

A `workflow_dispatch` input arrives as the **string** `"false"` when the box is left unticked, and a non-empty string is truthy in a GitHub expression. So `!(true && "false")` evaluates to `false` and the job skips — every manual run was read as a dry run.

Because a skipped job counts as a pass in `ci-ok`, the run still went green.

## Why it matters

This is the failure the job's own comment argues against. It was written with no `continue-on-error` precisely because a check that reports green whatever happened is worse than no check at all; skipping silently lands in the same place by a different route.

It bites hardest on the runs where it is the *only* real verification. A manual dispatch with `force_website` is how a bundle left stale by a failed apply gets shipped — and that is exactly when nothing else has exercised production, because `web-checks` and `web-e2e` skip on the cached digest marker. The deploy goes out with no test between it and the live site.

Observed on [run 30519068709](https://github.com/RetroHazard/CloudResume/actions/runs/30519068709), which deployed the signed-download bundle and reported success with the smoke test skipped. That run was the first deploy of the `/download` button, so `cv-download-live.cy.js` — the one spec that proves the SSM private key and the CloudFront public key actually agree — has still never run against production.

## The change

One line: compare against `true` explicitly.

```diff
-          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+          && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
```

Lines 620 and 624 already do this; this brings the third use into line. A comment records why the bare form is wrong, so it does not get simplified back.

Nothing else uses an input for truthiness in an `if:`. Line 857 passes `dry_run` to a shell string comparison, which is unaffected.

## Verifying

Merging this alone will not run the smoke test — this PR touches only `.github/`, so `web-deploy` is skipped and `web-smoke` has nothing to follow. After merge, dispatch the Pipeline from `main` with `force_website` ticked; `web-smoke` should then run rather than skip, and `cv-download-live.cy.js` will assert `200` + `application/pdf` on a freshly signed URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qb3x62UmRMuojEg98o7rMb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb3x62UmRMuojEg98o7rMb)_