### PR TITLE
fix(ci): lift the transitive skip that kept web-smoke off every deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,15 +923,28 @@ jobs:
     # real deploy and deserves the same check. Skipped for a dry run, which by
     # definition changed nothing.
     #
-    # `inputs.dry_run == true`, not a bare `inputs.dry_run`. A workflow_dispatch
+    # !cancelled() for the same reason web-deploy needs it, and it is the whole
+    # reason this job ever runs. The implicit "skip me if an upstream was
+    # skipped" rule propagates *transitively*: web-deploy lifts it for itself,
+    # but a skip further up the chain still reaches here through it, even though
+    # web-deploy ran and succeeded. Something upstream is almost always skipped
+    # on a deploy — terraform on a website-only change, web-checks and web-e2e
+    # whenever the digest marker hits — so without this the job skipped on
+    # essentially every real deploy. A skipped job counts as a pass in ci-ok, so
+    # that went unnoticed: the deploys with no test between them and production
+    # were exactly the ones reporting green.
+    #
+    # The success of the one need that matters is re-asserted below, so lifting
+    # the implicit rule does not let a failed deploy through to the smoke test.
+    #
+    # `inputs.dry_run == true`, not a bare `inputs.dry_run`: a workflow_dispatch
     # input arrives as the *string* "false" when the box is left unticked, and a
-    # non-empty string is truthy in a GitHub expression — so the bare form read
-    # every manual run as a dry run and skipped this job. A skipped job counts as
-    # a pass in ci-ok, so the whole point of the job (see above) was silently
-    # lost on exactly the runs that deploy without a website commit behind them.
-    # The `== true` comparison coerces properly; lines 620 and 624 already do it.
+    # non-empty string is truthy in a GitHub expression, which would re-break the
+    # job the moment the propagation above stopped masking it. Lines 620 and 624
+    # already compare explicitly.
     if: >-
-      ${{ needs.web-deploy.result == 'success'
+      ${{ !cancelled()
+          && needs.web-deploy.result == 'success'
           && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
     permissions:
       contents: read


### PR DESCRIPTION
Follow-up to #121, which was necessary but not the cause. With it merged, the smoke test still skipped.

## Evidence

On [run 30519728709](https://github.com/RetroHazard/CloudResume/actions/runs/30519728709), the `ci-ok` gate recorded:

```
web-deploy: success
web-smoke:  skipped
All checks passed or were skipped.
```

`web-deploy` succeeded, so `needs.web-deploy.result == 'success'` was true and the condition as written evaluated true. The skip was **structural, not conditional** — which is why changing the `dry_run` comparison moved nothing.

## Cause

The implicit *"skip me if an upstream was skipped"* rule propagates through the whole chain, not just direct needs. `web-deploy` lifts it for itself with `!cancelled()` — as its own comment describes — but a skip further up still reaches `web-smoke` through it, even though `web-deploy` ran and succeeded. `web-smoke`'s condition carried no status-check function, so it never lifted the rule for itself.

Something upstream is skipped on essentially every deploy, so the job never fired once:

| Run | Skipped upstream | `web-smoke` |
|---|---|---|
| [30519068709](https://github.com/RetroHazard/CloudResume/actions/runs/30519068709) | `web-checks`, `web-e2e` — digest marker hit | skipped |
| [30519728709](https://github.com/RetroHazard/CloudResume/actions/runs/30519728709) | `terraform` — no `force_infrastructure` | skipped |

Different upstream each time, same outcome.

Because `ci-ok` treats a skip as a pass, this was invisible: the deploys with no test between them and production were exactly the ones reporting green.

## The change

```diff
 if: >-
-  ${{ needs.web-deploy.result == 'success'
+  ${{ !cancelled()
+      && needs.web-deploy.result == 'success'
       && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
```

`!cancelled()` lifts the rule for every need at once, so the success of the one that matters is re-asserted explicitly alongside it — a failed deploy still cannot reach the smoke test. This mirrors `web-deploy` directly above.

The `inputs.dry_run == true` comparison from #121 is kept. It was not the cause, but the bare form would re-break the job as soon as this propagation stopped masking it.

## Verifying

Merging this alone won't run the smoke test — the PR touches only `.github/`, so `web-deploy` is skipped and `web-smoke` has nothing to follow. After merge, dispatch the Pipeline from `main` with `force_website` ticked and `dry_run` off. `Production smoke test` should then **run rather than skip**, which is itself the proof.

That run would also be the first time `cv-download-live.cy.js` executes against production — the only check that confirms the SSM private key and the CloudFront public key agree, by fetching a freshly minted signed URL and asserting `200` + `application/pdf`.

## Worth a follow-up

`ci-ok` reporting `All checks passed or were skipped` is what let this hide. Making it assert that `web-smoke` is not `skipped` on a `main` deploy would turn this class of bug into a red check instead of a silent one. Happy to do that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qb3x62UmRMuojEg98o7rMb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb3x62UmRMuojEg98o7rMb)_