### PR TITLE
fix(ci): fail the gate when a deploy ships without a smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1011,6 +1011,7 @@ jobs:
       - name: Check results
         env:
           RESULTS: ${{ toJSON(needs) }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: |
           set -euo pipefail
           echo "$RESULTS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
@@ -1024,4 +1025,29 @@ jobs:
             echo "::error::Failed or cancelled: $(echo "$bad" | tr '\n' ' ')"
             exit 1
           fi
+
+          # Everything above treats a skip as a pass, which is correct for jobs
+          # that genuinely had nothing to do — and is exactly what hid web-smoke
+          # silently not running across four consecutive deploys. Two different
+          # bugs (a truthy "false" string, then transitive skip propagation) both
+          # landed as a skip, and a skip is indistinguishable from a pass here.
+          #
+          # So the one case where that distinction matters gets asserted
+          # positively: if the site was really deployed, it must also have been
+          # smoke tested. This cannot catch a skip in the abstract — only a skip
+          # that left production untested, which is the part worth failing over.
+          #
+          # No branch check is needed: web-deploy only runs on main, so its
+          # success already implies it. A dry run deploys nothing, so a skipped
+          # smoke test is correct there and is excluded.
+          web_deploy=$(echo "$RESULTS" | jq -r '.["web-deploy"].result')
+          web_smoke=$(echo "$RESULTS" | jq -r '.["web-smoke"].result')
+
+          if [ "$web_deploy" = "success" ] \
+             && [ "${DRY_RUN:-false}" != "true" ] \
+             && [ "$web_smoke" != "success" ]; then
+            echo "::error::web-deploy succeeded but web-smoke did not run (result: ${web_smoke}). Production was deployed with nothing verifying it. This is a bug in web-smoke's if: condition, not a pass."
+            exit 1
+          fi
+
           echo "All checks passed or were skipped."


### PR DESCRIPTION
Closes the hole that let #121 and #122 hide.

## Why

`ci-ok` treats a skipped job as a pass — correct for jobs that genuinely had nothing to do, and exactly what concealed `web-smoke` silently not running across four consecutive deploys. Two unrelated bugs (a truthy `"false"` string, then transitive skip propagation) both surfaced as a *skip*, and a skip is indistinguishable from a pass here. Every one of those runs reported green while shipping to production with nothing testing it.

The gate can't tell *"did not need to run"* from *"silently stopped running"* in the general case. So this asserts the one case where the difference matters: **if `web-deploy` succeeded, `web-smoke` must have succeeded too.**

## Scoping

| Case | Handling |
|---|---|
| Branch | No check needed — `web-deploy` only runs on `main`, so its success already implies it |
| Dry run | Excluded — a dry run deploys nothing, so a skipped smoke test is correct |
| Failed `web-smoke` | Already caught by the existing failure check above |
| PR runs | `web-deploy` is skipped, so the guard never fires |

## Verification

I extracted the step's script from the YAML and ran it against the real `toJSON(needs)` shapes, including a replay of [run 30519728709](https://github.com/RetroHazard/CloudResume/actions/runs/30519728709) — the one that deployed with `web-deploy: success` / `web-smoke: skipped` and still went green:

```
normal deploy, smoke ran                   exit=0  PASS
THE BUG: deployed, smoke skipped           exit=1  PASS
dry run, smoke skipped (legit)             exit=0  PASS
PR / no deploy happened                    exit=0  PASS
a real job failed                          exit=1  PASS
```

The second case is the regression this exists to catch; it now fails with:

```
::error::web-deploy succeeded but web-smoke did not run (result: skipped).
Production was deployed with nothing verifying it. This is a bug in
web-smoke's if: condition, not a pass.
```

## Note on this PR's own CI

This PR touches only `.github/`, so `web-deploy` skips and the new guard correctly does not fire — its own run can't exercise it. The first real exercise is the next `main` deploy, where it should stay silent now that `web-smoke` runs (confirmed passing on [run 30520387771](https://github.com/RetroHazard/CloudResume/actions/runs/30520387771), 21/21 specs including `cv-download-live.cy.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qb3x62UmRMuojEg98o7rMb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb3x62UmRMuojEg98o7rMb)_