### PR TITLE
Add live API smoke tests and expand post-deploy verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,16 @@ jobs:
       contents: read
     outputs:
       secrets_changed: ${{ steps.secrets.outputs.changed }}
+      # Whether this run actually mutated production. Read off the Apply step's own
+      # outcome rather than reconstructed from the plan and the event, because the
+      # step's `if:` already encodes every condition (main, non-empty plan, not a dry
+      # run) and a second copy of that expression would be one more thing to drift.
+      # A step the `if:` excluded reports `skipped`, so the empty-plan, PR and dry-run
+      # paths all resolve to false without any extra guarding.
+      #
+      # `smoke` and `ci-ok` both consume this: an apply is the other way production
+      # changes, and until it was exposed nothing downstream could tell that it had.
+      applied: ${{ steps.apply.outcome == 'success' }}
     defaults:
       run:
         working-directory: infrastructure
@@ -613,6 +623,7 @@ jobs:
       # PAT. It is also pinned to the state's lineage and serial, so anything
       # applied in the meantime makes it stale rather than merely out of date.
       - name: Apply
+        id: apply
         if: >-
           ${{ github.ref == 'refs/heads/main'
               && steps.plan.outputs.changes == 'true'
@@ -910,11 +921,23 @@ jobs:
               fi
             done
 
-  web-smoke:
+  smoke:
     name: Production smoke test
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [web-deploy]
+    needs: [terraform, web-deploy]
+    # Runs after *either* way production can change, which is why this is one job
+    # rather than a web one and an infra one. It used to hang off web-deploy alone,
+    # and web-deploy is deliberately narrow — website/ changed, or the plan rewrote
+    # the Actions secrets — so every Lambda edit, API Gateway change, CloudFront
+    # behaviour and IAM tweak applied straight to production with nothing verifying
+    # it afterwards. That is the gap issue #44 names.
+    #
+    # Merged rather than duplicated: a run that changes both stacks would otherwise
+    # smoke test the same site twice, and the specs are the same either way. An
+    # apply can break the site (a bad cache behaviour, a detached Lambda permission)
+    # and a deploy can break the API contract, so both paths want the whole set.
+    #
     # No continue-on-error. The old post-deploy Cypress job had it, which meant
     # it rendered as a green check whatever happened — strictly worse than not
     # running at all. A red smoke here means production has already changed and
@@ -932,10 +955,15 @@ jobs:
     # whenever the digest marker hits — so without this the job skipped on
     # essentially every real deploy. A skipped job counts as a pass in ci-ok, so
     # that went unnoticed: the deploys with no test between them and production
-    # were exactly the ones reporting green.
+    # were exactly the ones reporting green. The second `needs:` edge added here
+    # makes that rule matter more, not less: on an infrastructure-only apply
+    # web-deploy is itself skipped, and that skip reaches this job too.
     #
-    # The success of the one need that matters is re-asserted below, so lifting
-    # the implicit rule does not let a failed deploy through to the smoke test.
+    # The successes that matter are re-asserted below, so lifting the implicit
+    # rule does not let a failed deploy through to the smoke test. web-deploy is
+    # tested for `!= 'failure'` rather than `== 'success'` because it is legitimately
+    # skipped on the apply-only path — the `||` above is what says production
+    # changed at all.
     #
     # `inputs.dry_run == true`, not a bare `inputs.dry_run`: a workflow_dispatch
     # input arrives as the *string* "false" when the box is left unticked, and a
@@ -944,7 +972,8 @@ jobs:
     # already compare explicitly.
     if: >-
       ${{ !cancelled()
-          && needs.web-deploy.result == 'success'
+          && (needs.web-deploy.result == 'success' || needs.terraform.outputs.applied == 'true')
+          && needs.web-deploy.result != 'failure' && needs.web-deploy.result != 'cancelled'
           && !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
     permissions:
       contents: read
@@ -968,7 +997,18 @@ jobs:
         run: pnpm exec cypress install
 
       # A subset only: enough to prove the deployed site boots, routes and
-      # renders. The full suite already gated this content on the PR.
+      # renders, and that the stack behind it answers. The full suite already
+      # gated this content on the PR.
+      #
+      # Cypress exposes CYPRESS_FOO as Cypress.env('foo'), which is how the three
+      # values below reach api-live.cy.js and bucket-locked.cy.js. Every request
+      # those specs make is anonymous, so no AWS credentials are needed here — and
+      # the specs skip themselves when a value is absent, which is what keeps them
+      # inert in web-e2e, where `pnpm cypress:run` globs them against a local
+      # preview with none of this set.
+      #
+      # Both secrets are registered, so Actions masks them in the run banner
+      # Cypress prints on start.
       - name: Smoke test production
         uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6
         with:
@@ -977,6 +1017,9 @@ jobs:
           command: pnpm cypress:smoke
         env:
           CYPRESS_BASE_URL: https://${{ vars.AWS_TF_DOMAIN_NAME }}
+          CYPRESS_API_ENDPOINT: ${{ secrets.AWS_API_ENDPOINT }}
+          CYPRESS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_PROD }}
+          CYPRESS_AWS_REGION: ${{ vars.AWS_TF_DEPLOYMENT_REGION }}
 
       - name: Upload screenshots on failure
         if: failure()
@@ -991,7 +1034,7 @@ jobs:
   # outcome for a stack that did not change, or for checks a marker already
   # covered — still counts as a pass.
   #
-  # web-deploy and web-smoke are in here so that on a push this is also the one
+  # web-deploy and smoke are in here so that on a push this is also the one
   # status that says whether the deploy landed. `needs:` only orders jobs; it
   # never runs one its own `if:` excludes, and on a pull_request both of them
   # are skipped by that `if:`, so nothing about the required check changes on a
@@ -1005,7 +1048,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ always() }}
-    needs: [changes, web-checks, web-e2e, terraform, py-lint, actionlint, web-deploy, web-smoke]
+    needs: [changes, web-checks, web-e2e, terraform, py-lint, actionlint, web-deploy, smoke]
 
     steps:
       - name: Check results
@@ -1027,26 +1070,38 @@ jobs:
           fi
 
           # Everything above treats a skip as a pass, which is correct for jobs
-          # that genuinely had nothing to do — and is exactly what hid web-smoke
-          # silently not running across four consecutive deploys. Two different
-          # bugs (a truthy "false" string, then transitive skip propagation) both
-          # landed as a skip, and a skip is indistinguishable from a pass here.
+          # that genuinely had nothing to do — and is exactly what hid the smoke
+          # test silently not running across four consecutive deploys. Two
+          # different bugs (a truthy "false" string, then transitive skip
+          # propagation) both landed as a skip, and a skip is indistinguishable
+          # from a pass here.
           #
           # So the one case where that distinction matters gets asserted
-          # positively: if the site was really deployed, it must also have been
-          # smoke tested. This cannot catch a skip in the abstract — only a skip
-          # that left production untested, which is the part worth failing over.
+          # positively: if production really changed, it must also have been smoke
+          # tested. This cannot catch a skip in the abstract — only a skip that
+          # left production untested, which is the part worth failing over.
           #
-          # No branch check is needed: web-deploy only runs on main, so its
-          # success already implies it. A dry run deploys nothing, so a skipped
-          # smoke test is correct there and is excluded.
+          # There are two ways production changes and both are checked, because
+          # for most of this pipeline's life only the first one was: a Terraform
+          # apply with no website change ran with nothing behind it at all, and
+          # that reported green by the same skip-is-a-pass rule above.
+          #
+          # `applied` is a job *output*, and toJSON(needs) carries outputs as well
+          # as results, so it can be read from the same blob. It is the string
+          # "false" or absent when no apply ran, both of which fail the equality.
+          #
+          # No branch check is needed: web-deploy and the Apply step both only run
+          # on main, so either being a success already implies it. A dry run
+          # changes nothing, so a skipped smoke test is correct there and is
+          # excluded.
           web_deploy=$(echo "$RESULTS" | jq -r '.["web-deploy"].result')
-          web_smoke=$(echo "$RESULTS" | jq -r '.["web-smoke"].result')
+          applied=$(echo "$RESULTS" | jq -r '.terraform.outputs.applied // "false"')
+          smoke=$(echo "$RESULTS" | jq -r '.smoke.result')
 
-          if [ "$web_deploy" = "success" ] \
+          if { [ "$web_deploy" = "success" ] || [ "$applied" = "true" ]; } \
              && [ "${DRY_RUN:-false}" != "true" ] \
-             && [ "$web_smoke" != "success" ]; then
-            echo "::error::web-deploy succeeded but web-smoke did not run (result: ${web_smoke}). Production was deployed with nothing verifying it. This is a bug in web-smoke's if: condition, not a pass."
+             && [ "$smoke" != "success" ]; then
+            echo "::error::Production changed (web-deploy: ${web_deploy}, terraform applied: ${applied}) but smoke did not run (result: ${smoke}). Production was changed with nothing verifying it. This is a bug in smoke's if: condition, not a pass."
             exit 1
           fi
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -16,17 +16,16 @@ web-checks  web-e2e   terraform    py-lint    actionlint
  typecheck  build +   fmt/validate   ruff      (.github
  prettier   preview   plan                      changed)
  vitest     cypress   apply ──[main only, if the plan is non-empty]
-    │          │      ↳ secrets_changed?
+    │          │      ↳ secrets_changed? applied?
     │          │          │
     ├──────────┴──────────┴─────┬──────────────┐
     ▼                           ▼              │
 mark-verified              web-deploy          │
   (PR only)                build-prod          │
   web/ruff/actionlint      + s3 sync           │
-  markers                                      │
-                                │              │
+  markers                       │              │
                                 ▼              │
-                            web-smoke          │
+                              smoke ◀──[also on an apply with no deploy]
                                 │              │
                                 └──────────────┤
                                                ▼
@@ -35,6 +34,7 @@ mark-verified              web-deploy          │
 ```
 
 `web-deploy` runs when `website` changed **or** the plan rewrote the Actions secrets — see below.
+`smoke` runs when `web-deploy` succeeded **or** the apply actually ran.
 
 `ci-ok` is the single required status check. Everything else can be renamed without touching branch
 protection, and a job skipped by `if:` — the normal outcome for a stack that did not change — counts
@@ -126,6 +126,52 @@ The one case it cannot see is an apply that succeeded while the deploy after it 
 plans clean, so nothing signals that the bundle is behind. `workflow_dispatch` with `force_website`
 is the recovery path.
 
+**The smoke test hangs off both.** That narrow deploy gate is right for deciding whether to re-upload
+the bundle and wrong for deciding whether production needs checking. `smoke` used to need only
+`web-deploy`, so every Lambda edit, API Gateway change, CloudFront behaviour and IAM tweak applied
+straight to production with nothing running afterwards — and reported green, because a skipped job
+counts as a pass. It now runs on `web-deploy.result == 'success' || terraform.outputs.applied ==
+'true'`, where `applied` is read off the `Apply` step's own `outcome`. That step's `if:` already
+encodes every condition — `main`, a non-empty plan, not a dry run — and a step excluded by `if:`
+reports `skipped`, so the empty-plan, PR and dry-run paths all resolve to `false` without a second
+copy of the expression to keep in sync.
+
+One job rather than one per stack: an apply can break the site and a deploy can break the API
+contract, so both paths want the same specs, and a run that changes both stacks would otherwise
+smoke test the same site twice. `web-deploy` is tested for `!= 'failure'` rather than `== 'success'`
+alongside the `||`, because it is legitimately skipped on the apply-only path.
+
+`ci-ok` asserts the pairing positively, in both directions: if `web-deploy` succeeded **or** the
+apply ran, `smoke` must have succeeded. `toJSON(needs)` carries job outputs as well as results, so
+the same blob the gate already reads holds `applied`. Everything else in that job treats a skip as a
+pass — correct for a stack that did not change, and exactly what hid the smoke test not running
+across four consecutive deploys (#121–#123). This is the one place the distinction is worth failing
+over.
+
+**What the smoke test covers.** `pnpm cypress:smoke` runs six specs against
+`https://<domain>`, all of them skipping themselves when pointed at a local preview:
+
+| Spec | Proves |
+| --- | --- |
+| `navigation.cy.js` | CloudFront serves 200 on the apex, every SPA route, and the 404 fallback |
+| `visitor-counter.cy.js` | the counter renders (API stubbed) |
+| `files-locked.cy.js` | the edge rejects an unsigned `/files/*` |
+| `bucket-locked.cy.js` | the S3 origin rejects an anonymous read — the other half of the CloudFront-only policy, and the only thing testing it, since there is no `aws_s3_bucket_public_access_block` on the prod bucket |
+| `cv-download-live.cy.js` | a real signed URL fetches the PDF: API GW → Lambda → SSM → DynamoDB → CloudFront key group all agree |
+| `api-live.cy.js` | `GET /visitors` returns JSON with a numeric `count` and the right CORS origin; both request validators still reject a missing querystring at the gateway; `POST /contact` reaches its Lambda |
+
+The two live API specs need `CYPRESS_API_ENDPOINT`, `CYPRESS_S3_BUCKET` and `CYPRESS_AWS_REGION` in
+addition to `CYPRESS_BASE_URL`; every request they make is anonymous, so no AWS credentials are
+involved. `/contact` is probed with a deliberately foreign `Origin`, which `sendMessage` refuses
+before it ever constructs an SES client — that is what proves the route is alive without emailing a
+human on every deploy. The 403 assertion checks the body text as well as the status, because API
+Gateway answers a request for a route that does not exist with a 403 of its own.
+
+Both live specs reuse a fixed identifier (`ci-smoke-test`) for the `visitorId` and `uuid`
+querystrings. `trackVisitors` and `downloadResume` both write a record with a 24-hour TTL and only
+count on a miss, so repeat deploys are absorbed by the dedupe rather than inflating the public
+counters once per push to `main`.
+
 **`terraform apply` consumes the saved plan** rather than re-planning, so what lands is what was
 reviewed a step earlier. The plan is handed straight from the plan step to the apply step within one
 job, and is never carried between runs. Reusing a PR's plan for the post-merge apply would eliminate
@@ -201,6 +247,14 @@ pnpm format:check     # prettier --check .
 pnpm test             # vitest run --coverage
 pnpm build-dev && pnpm preview   # then pnpm cypress:run in another shell
 
+# The smoke set against production. Without the three extra variables the two live
+# API specs skip themselves, exactly as they do in the PR e2e job.
+CYPRESS_BASE_URL=https://<domain> \
+CYPRESS_API_ENDPOINT=<api endpoint> \
+CYPRESS_S3_BUCKET=<prod bucket> \
+CYPRESS_AWS_REGION=<region> \
+pnpm cypress:smoke
+
 ruff check infrastructure/codebase/ && ruff format --check infrastructure/codebase/
 actionlint
 cd infrastructure && terraform fmt -check -recursive && terraform validate
@@ -227,7 +281,7 @@ edge. Four jobs each re-ran `pnpm install`, one of them (`setup`) only to instal
 away because it existed to carry an `if:` gate; the build reached `deploy` smuggled through
 `actions/cache` keyed on `github.sha`. Unit tests re-ran post-merge on content the PR had already
 proved — the markers above are what fixed that. And the post-deploy Cypress job carried
-`continue-on-error: true`, so it rendered green whatever happened; `web-smoke` does not, and runs a
+`continue-on-error: true`, so it rendered green whatever happened; `smoke` does not, and runs a
 subset rather than the full suite.
 
 Deleting `infrastructure-test.yml` also removed a second plan against the same remote state on every

--- a/website/cypress/e2e/api-live.cy.js
+++ b/website/cypress/e2e/api-live.cy.js
@@ -1,0 +1,108 @@
+// The API half of the post-apply smoke test: three routes on the real API Gateway stage,
+// exercised without a browser and without mutating anything a human would notice.
+//
+// Everything else in the suite stubs these endpoints — cy.stubVisitorApi intercepts
+// GET /visitors in every spec that loads a page, and contact-form.cy.js intercepts the POST.
+// That is correct for testing the frontend and useless for testing the stack: a deleted route,
+// a detached request validator, a Lambda whose permission was revoked, or an integration
+// pointing at a stale function ARN all look identical from a stubbed test.
+//
+// These run against a deployed stage or not at all, so they carry the same localhost guard as
+// files-locked.cy.js and cv-download-live.cy.js, plus one on the endpoint itself — the PR e2e
+// job has no CYPRESS_API_ENDPOINT and must skip rather than fail.
+describe('Live API (production)', () => {
+    const apiEndpoint = (Cypress.env('apiEndpoint') || '').replace(/\/$/, '');
+    const baseUrl = Cypress.config('baseUrl') || '';
+
+    // A stable id, exactly as cv-download-live.cy.js uses for the download uuid. trackVisitors
+    // writes a visitor record with a 24h TTL and only increments the counter on a miss, so
+    // reusing one id means repeat deploys are absorbed by the dedupe instead of inflating the
+    // public count once per push to main.
+    const SMOKE_ID = 'ci-smoke-test';
+
+    beforeEach(function () {
+        if (!apiEndpoint || baseUrl.includes('localhost') || baseUrl.includes('127.0.0.1')) {
+            this.skip();
+        }
+    });
+
+    describe('GET /visitors', () => {
+        it('returns the visitor count as JSON', () => {
+            cy.request({
+                method: 'GET',
+                url: `${apiEndpoint}/visitors?visitorId=${SMOKE_ID}`,
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status, 'status').to.eq(200);
+                expect(response.headers['content-type'] || '').to.contain('application/json');
+
+                // cy.request parses a JSON body for us, so this is the object itself. Asserting
+                // the type rather than a value: the count only ever goes up, and pinning it to
+                // anything would make the test a clock.
+                expect(response.body, 'body').to.have.property('count');
+                expect(response.body.count, 'count').to.be.a('number');
+
+                // The Lambda echoes its allowedOrigin env var here rather than '*'
+                // (infrastructure/codebase/trackVisitors.py). If that ever drifts from the site
+                // origin the counter silently disappears in the browser — the component returns
+                // null on a failed fetch — and nothing else in the suite would notice, because
+                // every other test stubs this response.
+                expect(response.headers['access-control-allow-origin'], 'CORS origin').to.eq(
+                    baseUrl.replace(/\/$/, ''),
+                );
+            });
+        });
+
+        // The method declares method.request.querystring.visitorId as required and attaches
+        // crc-api-param-validator. trackVisitors indexes straight into queryStringParameters,
+        // so if the validator is ever detached this becomes a KeyError and a 500 — which is a
+        // Lambda invocation and a CloudWatch error for anyone who curls the endpoint bare.
+        it('rejects a request with no visitorId at the gateway', () => {
+            cy.request({
+                method: 'GET',
+                url: `${apiEndpoint}/visitors`,
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status, 'status').to.eq(400);
+            });
+        });
+    });
+
+    describe('POST /contact', () => {
+        // Same validator, on method.request.querystring.uuid.
+        it('rejects a request with no uuid at the gateway', () => {
+            cy.request({
+                method: 'POST',
+                url: `${apiEndpoint}/contact`,
+                body: {},
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status, 'status').to.eq(400);
+            });
+        });
+
+        // The only way to prove the contact route is alive without emailing a human on every
+        // deploy. sendMessage compares the Origin header against its allowedOrigin and returns
+        // before it ever constructs an SES client, so a deliberately foreign origin exercises
+        // the whole path — route, AWS_PROXY integration, lambda:InvokeFunction permission, cold
+        // start — and sends nothing.
+        //
+        // The body assertion is the load-bearing half. API Gateway answers a request for a route
+        // that does not exist with its own 403 and {"message":"Missing Authentication Token"},
+        // so a status-only check would pass just as happily against a deleted /contact resource.
+        it('reaches the Lambda and is refused on origin', () => {
+            cy.request({
+                method: 'POST',
+                url: `${apiEndpoint}/contact?uuid=${SMOKE_ID}`,
+                headers: { Origin: 'https://smoke.invalid' },
+                body: { firstName: 'CI', lastName: 'Smoke', email: 'ci@smoke.invalid' },
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status, 'status').to.eq(403);
+                expect(JSON.stringify(response.body), 'rejected by the Lambda, not the gateway').to.contain(
+                    'Forbidden: Invalid origin',
+                );
+            });
+        });
+    });
+});

--- a/website/cypress/e2e/bucket-locked.cy.js
+++ b/website/cypress/e2e/bucket-locked.cy.js
@@ -1,0 +1,37 @@
+// The origin half of the CloudFront-only policy.
+//
+// files-locked.cy.js proves the *edge* rejects an unsigned /files/* request. This proves the
+// bucket behind it rejects an anonymous request outright, which is a different property and
+// currently rests on one thing: the OAC bucket policy in modules/frontend. There is no
+// aws_s3_bucket_public_access_block on the prod bucket, so a policy that ever grew a
+// Principal: "*" statement — or lost the aws:SourceArn condition tying it to the distribution
+// — would serve the whole site straight off S3, bypassing the CDN, the signed-download gate on
+// /files/*, and the access logging. Terraform would report that apply as a clean success.
+describe('Website bucket origin', () => {
+    const bucket = Cypress.env('s3Bucket');
+    const region = Cypress.env('awsRegion');
+
+    it('refuses an anonymous request to the S3 endpoint', function () {
+        if (!bucket || !region) {
+            // No bucket name locally, and nothing to point this at — see files-locked.cy.js.
+            this.skip();
+        }
+
+        cy.request({
+            // The regional endpoint, not the global one: the bucket is created under the root
+            // provider's var.deployment_region, and s3.amazonaws.com answers a request for a
+            // bucket outside us-east-1 with a 301 PermanentRedirect rather than the 403 this
+            // is looking for.
+            url: `https://${bucket}.s3.${region}.amazonaws.com/index.html`,
+            failOnStatusCode: false,
+            // A redirect must surface as a redirect. Following one would let this assert
+            // against whatever it landed on instead of against the bucket.
+            followRedirect: false,
+        }).then((response) => {
+            expect(response.status, 'anonymous read of the origin').to.eq(403);
+            // Status alone is ambiguous — 403 is also what a redirect chain or a fronting proxy
+            // could produce. The S3 error document names the reason.
+            expect(String(response.body), 'S3 AccessDenied document').to.contain('AccessDenied');
+        });
+    });
+});

--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
         "preview": "vite preview --outDir build/dev --port 5173",
         "cypress:open": "cypress open",
         "cypress:run": "cypress run",
-        "cypress:smoke": "cypress run --spec 'cypress/e2e/navigation.cy.js,cypress/e2e/visitor-counter.cy.js,cypress/e2e/files-locked.cy.js,cypress/e2e/cv-download-live.cy.js'"
+        "cypress:smoke": "cypress run --spec 'cypress/e2e/navigation.cy.js,cypress/e2e/visitor-counter.cy.js,cypress/e2e/files-locked.cy.js,cypress/e2e/cv-download-live.cy.js,cypress/e2e/api-live.cy.js,cypress/e2e/bucket-locked.cy.js'"
     },
     "pnpm": {
         "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary
Extends the post-deployment smoke test suite to verify the infrastructure stack in addition to the website, ensuring that Lambda functions, API Gateway routes, and their integrations are working correctly in production.

## Key Changes

- **New live API test spec** (`api-live.cy.js`): Tests three real API Gateway endpoints without mocking:
  - `GET /visitors` returns valid JSON with correct CORS headers
  - Request validators reject missing required querystring parameters at the gateway
  - `POST /contact` reaches its Lambda function (verified by testing origin validation)

- **New S3 origin test spec** (`bucket-locked.cy.js`): Verifies the CloudFront origin bucket rejects anonymous requests, ensuring the OAC policy is correctly configured

- **Renamed and expanded smoke test job**: `web-smoke` → `smoke`
  - Now runs after either `web-deploy` succeeds OR the Terraform `apply` step succeeds
  - Covers both website and infrastructure changes with a single test suite
  - Prevents infrastructure-only applies from bypassing verification

- **Terraform output for apply status**: Added `applied` output to the `terraform` job that captures whether the `Apply` step actually ran and succeeded, enabling downstream jobs to detect infrastructure changes

- **Enhanced CI gate logic** (`ci-ok`): Now asserts that if production changed (either via deploy or apply), the smoke test must have run and succeeded, catching the case where infrastructure changes were deployed with no verification

- **Updated documentation** (`docs/ci.md`): Explains the expanded smoke test coverage, the two paths that trigger it, and what each spec verifies

## Implementation Details

- Live API specs require `CYPRESS_API_ENDPOINT`, `CYPRESS_S3_BUCKET`, and `CYPRESS_AWS_REGION` environment variables and skip themselves when absent (same behavior as in PR e2e runs)
- Both live specs reuse a fixed `ci-smoke-test` identifier for querystring parameters to avoid inflating counters on repeat deploys (24-hour TTL deduplication)
- The `/contact` endpoint is tested with a deliberately foreign `Origin` header, which the Lambda rejects before constructing an SES client—proving the route is alive without sending emails
- Request validator tests check for 400 status at the API Gateway level, catching detached validators or missing parameter declarations
- All requests are anonymous; no AWS credentials needed in the CI environment

https://claude.ai/code/session_01HhCBs1wH7wmjXVQF3b22NM