### PR TITLE
Support promotion tracks in career history

### DIFF
--- a/website/src/__tests__/ExperienceList.test.js
+++ b/website/src/__tests__/ExperienceList.test.js
@@ -1,5 +1,33 @@
 import { render } from '@testing-library/react';
 import ExperienceList from '../components/experience_list';
+import { useJsonData } from '../utils/useJsonData';
+
+// An employer held across a promotion: one entry, a newest-first `roles` array,
+// company facts hoisted to the top level.
+const promotionEntry = {
+    company: 'Promoting Company',
+    location: 'Promoting Location',
+    type: 'Promoting Type',
+    logo: './images/placeholder.png',
+    website: 'https://promotingwebsite.com',
+    roles: [
+        {
+            job_title: 'Senior Generic Title',
+            transition: 'Promoted',
+            start: '2023-01',
+            end: '2025-09',
+            details: ['Senior detail 1', 'Senior detail 2'],
+            technologies: [{ name: 'Senior Skill', logo: 'ph:placeholder-fill', website: 'https://seniorskill.com' }],
+        },
+        {
+            job_title: 'Junior Generic Title',
+            start: '2021-04',
+            end: '2023-01',
+            details: ['Junior detail 1', 'Junior detail 2'],
+            technologies: [{ name: 'Junior Skill', logo: 'ph:placeholder-fill', website: 'https://juniorskill.com' }],
+        },
+    ],
+};
 
 // Sample JSON data
 const sampleData = {
@@ -68,5 +96,46 @@ describe('ExperienceList Component', () => {
     it('matches snapshot', () => {
         const { container } = render(<ExperienceList />);
         expect(container).toMatchSnapshot();
+    });
+
+    it('renders an employer held across a promotion as a single row', () => {
+        useJsonData.mockReturnValueOnce({
+            data: { Experience: [promotionEntry] },
+            loading: false,
+            error: null,
+        });
+        const { getAllByText, getByText, getByTitle } = render(<ExperienceList />);
+
+        // One board row, advertising the most recent title.
+        expect(getAllByText('Promoting Company')).toHaveLength(1);
+        expect(getByTitle('Senior Generic Title')).toBeInTheDocument();
+        expect(getByText('2 Roles')).toBeInTheDocument();
+
+        // The row spans the whole tenure, and each role keeps its own dates,
+        // bullets and skills.
+        expect(getByText('2021-04 — 2025-09')).toBeInTheDocument();
+        expect(getByText('2023-01 — 2025-09')).toBeInTheDocument();
+        expect(getByText('2021-04 — 2023-01')).toBeInTheDocument();
+        expect(getByText('Junior Generic Title')).toBeInTheDocument();
+        expect(getByText('Senior detail 1')).toBeInTheDocument();
+        expect(getByText('Junior detail 2')).toBeInTheDocument();
+        expect(getByText('Senior Skill')).toBeInTheDocument();
+        expect(getByText('Junior Skill')).toBeInTheDocument();
+
+        // The transition marker is dated by the role it leads into.
+        expect(getByText(/Promoted/)).toHaveTextContent('Promoted · 2023-01');
+    });
+
+    it('leaves the transition marker off a role that declares no transition', () => {
+        const [senior, junior] = promotionEntry.roles;
+        useJsonData.mockReturnValueOnce({
+            data: { Experience: [{ ...promotionEntry, roles: [{ ...senior, transition: undefined }, junior] }] },
+            loading: false,
+            error: null,
+        });
+        const { queryByText } = render(<ExperienceList />);
+
+        expect(queryByText(/Promoted/)).not.toBeInTheDocument();
+        expect(queryByText('Junior Generic Title')).toBeInTheDocument();
     });
 });

--- a/website/src/__tests__/__snapshots__/EducationList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/EducationList.test.js.snap
@@ -40,10 +40,14 @@ exports[`EducationList Component > matches snapshot 1`] = `
               class="flex min-w-0 flex-col"
             >
               <span
-                class="truncate font-heading text-base leading-tight font-bold tracking-wide text-content-title uppercase sm:text-lg"
-                title="Sample University"
+                class="flex min-w-0 items-center gap-2"
               >
-                Sample University
+                <span
+                  class="truncate font-heading text-base leading-tight font-bold tracking-wide text-content-title uppercase sm:text-lg"
+                  title="Sample University"
+                >
+                  Sample University
+                </span>
               </span>
               <span
                 class="truncate font-mono text-[0.7rem] text-neon"

--- a/website/src/__tests__/__snapshots__/ExperienceList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/ExperienceList.test.js.snap
@@ -40,10 +40,14 @@ exports[`ExperienceList Component > matches snapshot 1`] = `
               class="flex min-w-0 flex-col"
             >
               <span
-                class="truncate font-heading text-base leading-tight font-bold tracking-wide text-content-title uppercase sm:text-lg"
-                title="Generic Job Title"
+                class="flex min-w-0 items-center gap-2"
               >
-                Generic Job Title
+                <span
+                  class="truncate font-heading text-base leading-tight font-bold tracking-wide text-content-title uppercase sm:text-lg"
+                  title="Generic Job Title"
+                >
+                  Generic Job Title
+                </span>
               </span>
               <span
                 class="truncate font-mono text-[0.7rem] text-neon"

--- a/website/src/__tests__/__snapshots__/ProjectList.test.js.snap
+++ b/website/src/__tests__/__snapshots__/ProjectList.test.js.snap
@@ -40,10 +40,14 @@ exports[`ProjectList Component > matches snapshot 1`] = `
               class="flex min-w-0 flex-col"
             >
               <span
-                class="truncate font-heading text-base leading-tight font-bold tracking-wide text-content-title uppercase sm:text-lg"
-                title="Generic Project"
+                class="flex min-w-0 items-center gap-2"
               >
-                Generic Project
+                <span
+                  class="truncate font-heading text-base leading-tight font-bold tracking-wide text-content-title uppercase sm:text-lg"
+                  title="Generic Project"
+                >
+                  Generic Project
+                </span>
               </span>
               <span
                 class="truncate font-mono text-[0.7rem] text-neon"

--- a/website/src/assets/json/production/career_data.json
+++ b/website/src/assets/json/production/career_data.json
@@ -64,15 +64,14 @@
             "job_title": "Lead, IT Solutions",
             "location": "Tokyo, Japan",
             "type": "Full Time",
-            "start": "2021-04",
+            "start": "2023-01",
             "end": "2025-09",
             "logo": "./images/logos/companies/indeed.png",
             "website": "https://www.indeed.com/",
             "details": [
-                "Architecture and implementation lead for a Secure Global Printing Solution, improving printing reliability and scalability for over 10,000 users in Indeed offices around the world, reducing print-related issues by over 80%, reducing costs by up to 45%, and increasing user satisfaction by roughly 25%.",
-                "Implemented a comprehensive IT asset and inventory management system, achieving 99% accuracy in asset tracking, reducing procurement costs by 15%, and ensuring 100% compliance with organizational policies.",
-                "Led process improvement initiatives and streamlined workflows, reducing average ticket resolution time by 30% and increasing user satisfaction scores by 20%.",
-                "Led the IT Service Desk team, ensuring timely resolution of technical issues while maintaining clear and effective communication with stakeholders to align support services with business needs."
+                "Served as project lead and architect for a global enterprise printing solution across all regions outside the Americas, improving reliability and scalability for over 10,000 users, reducing print-related issues by 80%, lowering costs by 45%, and increasing user satisfaction by 25%.",
+                "Led the IT Service Desk team in Japan, mentoring engineers and driving performance enablement while partnering with stakeholders to align support services with evolving business needs.",
+                "Led process improvement initiatives and streamlined workflows, reducing average ticket resolution time by 30% and increasing user satisfaction scores by 20%."
             ],
             "technologies": [
                 {
@@ -109,6 +108,43 @@
                     "name": "GitLab",
                     "logo": "simple-icons:gitlab",
                     "website": "https://about.gitlab.com/"
+                },
+                {
+                    "name": "Linux",
+                    "logo": "simple-icons:linux",
+                    "website": "https://www.linux.org/"
+                }
+            ]
+        },
+        {
+            "company": "Indeed",
+            "job_title": "IT Support Specialist II",
+            "location": "Tokyo, Japan",
+            "type": "Full Time",
+            "start": "2021-04",
+            "end": "2023-01",
+            "logo": "./images/logos/companies/indeed.png",
+            "website": "https://www.indeed.com/",
+            "details": [
+                "Implemented a comprehensive IT asset and inventory management system, achieving 99% accuracy in asset tracking, reducing procurement costs by 15%, and ensuring 100% compliance with organizational policies.",
+                "Delivered frontline technical support across hardware, software, and access issues for 2000 local users, consistently meeting SLA targets and maintaining high customer-satisfaction scores.",
+                "Contributed to the initial implementation and regional deployment of a global enterprise printing solution, standing up 4 sites in Japan and validating configurations that established the foundation for a company-wide rollout."
+            ],
+            "technologies": [
+                {
+                    "name": "Jira",
+                    "logo": "simple-icons:jira",
+                    "website": "https://www.atlassian.com/software/jira"
+                },
+                {
+                    "name": "Confluence",
+                    "logo": "simple-icons:confluence",
+                    "website": "https://www.atlassian.com/software/confluence"
+                },
+                {
+                    "name": "Google Workspace",
+                    "logo": "simple-icons:google",
+                    "website": "https://workspace.google.com/"
                 },
                 {
                     "name": "Linux",

--- a/website/src/assets/json/production/career_data.json
+++ b/website/src/assets/json/production/career_data.json
@@ -61,95 +61,95 @@
         },
         {
             "company": "Indeed",
-            "job_title": "Lead, IT Solutions",
             "location": "Tokyo, Japan",
             "type": "Full Time",
-            "start": "2023-01",
-            "end": "2025-09",
             "logo": "./images/logos/companies/indeed.png",
             "website": "https://www.indeed.com/",
-            "details": [
-                "Served as project lead and architect for a global enterprise printing solution across all regions outside the Americas, improving reliability and scalability for over 10,000 users, reducing print-related issues by 80%, lowering costs by 45%, and increasing user satisfaction by 25%.",
-                "Led the IT Service Desk team in Japan, mentoring engineers and driving performance enablement while partnering with stakeholders to align support services with evolving business needs.",
-                "Led process improvement initiatives and streamlined workflows, reducing average ticket resolution time by 30% and increasing user satisfaction scores by 20%."
-            ],
-            "technologies": [
+            "roles": [
                 {
-                    "name": "AWS",
-                    "logo": "simple-icons:amazonaws",
-                    "website": "https://aws.amazon.com/"
+                    "job_title": "Lead, IT Solutions",
+                    "transition": "Promoted",
+                    "start": "2023-01",
+                    "end": "2025-09",
+                    "details": [
+                        "Served as project lead and architect for a global enterprise printing solution across all regions outside the Americas, improving reliability and scalability for over 10,000 users, reducing print-related issues by 80%, lowering costs by 45%, and increasing user satisfaction by 25%.",
+                        "Led the IT Service Desk team in Japan, mentoring engineers and driving performance enablement while partnering with stakeholders to align support services with evolving business needs.",
+                        "Led process improvement initiatives and streamlined workflows, reducing average ticket resolution time by 30% and increasing user satisfaction scores by 20%."
+                    ],
+                    "technologies": [
+                        {
+                            "name": "AWS",
+                            "logo": "simple-icons:amazonaws",
+                            "website": "https://aws.amazon.com/"
+                        },
+                        {
+                            "name": "Terraform",
+                            "logo": "simple-icons:terraform",
+                            "website": "https://www.terraform.io/"
+                        },
+                        {
+                            "name": "Jira",
+                            "logo": "simple-icons:jira",
+                            "website": "https://www.atlassian.com/software/jira"
+                        },
+                        {
+                            "name": "Confluence",
+                            "logo": "simple-icons:confluence",
+                            "website": "https://www.atlassian.com/software/confluence"
+                        },
+                        {
+                            "name": "CloudFlare",
+                            "logo": "simple-icons:cloudflare",
+                            "website": "https://www.cloudflare.com"
+                        },
+                        {
+                            "name": "Google Workspace",
+                            "logo": "simple-icons:google",
+                            "website": "https://workspace.google.com/"
+                        },
+                        {
+                            "name": "GitLab",
+                            "logo": "simple-icons:gitlab",
+                            "website": "https://about.gitlab.com/"
+                        },
+                        {
+                            "name": "Linux",
+                            "logo": "simple-icons:linux",
+                            "website": "https://www.linux.org/"
+                        }
+                    ]
                 },
                 {
-                    "name": "Terraform",
-                    "logo": "simple-icons:terraform",
-                    "website": "https://www.terraform.io/"
-                },
-                {
-                    "name": "Jira",
-                    "logo": "simple-icons:jira",
-                    "website": "https://www.atlassian.com/software/jira"
-                },
-                {
-                    "name": "Confluence",
-                    "logo": "simple-icons:confluence",
-                    "website": "https://www.atlassian.com/software/confluence"
-                },
-                {
-                    "name": "CloudFlare",
-                    "logo": "simple-icons:cloudflare",
-                    "website": "https://www.cloudflare.com"
-                },
-                {
-                    "name": "Google Workspace",
-                    "logo": "simple-icons:google",
-                    "website": "https://workspace.google.com/"
-                },
-                {
-                    "name": "GitLab",
-                    "logo": "simple-icons:gitlab",
-                    "website": "https://about.gitlab.com/"
-                },
-                {
-                    "name": "Linux",
-                    "logo": "simple-icons:linux",
-                    "website": "https://www.linux.org/"
-                }
-            ]
-        },
-        {
-            "company": "Indeed",
-            "job_title": "IT Support Specialist II",
-            "location": "Tokyo, Japan",
-            "type": "Full Time",
-            "start": "2021-04",
-            "end": "2023-01",
-            "logo": "./images/logos/companies/indeed.png",
-            "website": "https://www.indeed.com/",
-            "details": [
-                "Implemented a comprehensive IT asset and inventory management system, achieving 99% accuracy in asset tracking, reducing procurement costs by 15%, and ensuring 100% compliance with organizational policies.",
-                "Delivered frontline technical support across hardware, software, and access issues for 2000 local users, consistently meeting SLA targets and maintaining high customer-satisfaction scores.",
-                "Contributed to the initial implementation and regional deployment of a global enterprise printing solution, standing up 4 sites in Japan and validating configurations that established the foundation for a company-wide rollout."
-            ],
-            "technologies": [
-                {
-                    "name": "Jira",
-                    "logo": "simple-icons:jira",
-                    "website": "https://www.atlassian.com/software/jira"
-                },
-                {
-                    "name": "Confluence",
-                    "logo": "simple-icons:confluence",
-                    "website": "https://www.atlassian.com/software/confluence"
-                },
-                {
-                    "name": "Google Workspace",
-                    "logo": "simple-icons:google",
-                    "website": "https://workspace.google.com/"
-                },
-                {
-                    "name": "Linux",
-                    "logo": "simple-icons:linux",
-                    "website": "https://www.linux.org/"
+                    "job_title": "IT Support Specialist II",
+                    "start": "2021-04",
+                    "end": "2023-01",
+                    "details": [
+                        "Implemented a comprehensive IT asset and inventory management system, achieving 99% accuracy in asset tracking, reducing procurement costs by 15%, and ensuring 100% compliance with organizational policies.",
+                        "Delivered frontline technical support across hardware, software, and access issues for 2000 local users, consistently meeting SLA targets and maintaining high customer-satisfaction scores.",
+                        "Contributed to the initial implementation and regional deployment of a global enterprise printing solution, standing up 4 sites in Japan and validating configurations that established the foundation for a company-wide rollout."
+                    ],
+                    "technologies": [
+                        {
+                            "name": "Jira",
+                            "logo": "simple-icons:jira",
+                            "website": "https://www.atlassian.com/software/jira"
+                        },
+                        {
+                            "name": "Confluence",
+                            "logo": "simple-icons:confluence",
+                            "website": "https://www.atlassian.com/software/confluence"
+                        },
+                        {
+                            "name": "Google Workspace",
+                            "logo": "simple-icons:google",
+                            "website": "https://workspace.google.com/"
+                        },
+                        {
+                            "name": "Linux",
+                            "logo": "simple-icons:linux",
+                            "website": "https://www.linux.org/"
+                        }
+                    ]
                 }
             ]
         },

--- a/website/src/components/experience_list.jsx
+++ b/website/src/components/experience_list.jsx
@@ -1,8 +1,67 @@
 import { Icon } from '@iconify-icon/react';
 import { useJsonData, LoadingSkeleton } from '../utils/useJsonData';
 import SkillButton from './skill_button';
-import { Board, DepartureRow } from './ui/primitives';
+import { Board, Chip, DepartureRow } from './ui/primitives';
 import { formatDate, formatRange, isOngoing } from '../utils/dates';
+
+// A career entry is either a single posting (flat: job_title/start/end on the
+// entry itself) or one employer the line called at more than once — a
+// promotion, carried as a newest-first `roles` array. Both normalise to the
+// same shape here so the board only has to know about roles.
+const toRoles = (entry) => (Array.isArray(entry.roles) && entry.roles.length > 0 ? entry.roles : [entry]);
+
+// Bullets and skill chips, identical whether the role stands alone or is one
+// stop in a promotion track.
+const RoleBody = ({ role, index }) => (
+    <>
+        {role.details?.length > 0 && (
+            <ul className='ml-1 flex list-none flex-col gap-1.5 text-xs leading-relaxed text-content-body md:text-sm'>
+                {role.details.map((detail, detailIndex) => (
+                    <li key={`${index}-${detailIndex}`} className='flex gap-2'>
+                        <span aria-hidden='true' className='mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-neon/70' />
+                        <span>{detail}</span>
+                    </li>
+                ))}
+            </ul>
+        )}
+        <SkillButton skills={role.technologies} />
+    </>
+);
+
+// The promotion track: one stop per role, newest at the top, threaded on the
+// company's own line. The marker between two stops is drawn from the newer
+// role's `transition` label, so a lateral move never reads as a promotion.
+const RoleTrack = ({ roles, index }) => (
+    <ol className='ml-1 flex list-none flex-col gap-5 border-l border-border/70 pl-5'>
+        {roles.map((role, roleIndex) => (
+            <li key={`${role.job_title}-${role.start}`} className='relative flex flex-col gap-2'>
+                {/* Outlined rather than filled: the print stylesheet strips every
+                    background, and a filled dot would vanish on paper. */}
+                <span
+                    aria-hidden='true'
+                    className='absolute top-1 -left-[1.625rem] size-3 rounded-full border-2 border-neon bg-background'
+                />
+                <div className='flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5'>
+                    <p className='font-heading text-sm leading-tight font-bold tracking-wide text-content-title uppercase sm:text-base'>
+                        {role.job_title}
+                    </p>
+                    <p className='tabular font-mono text-[0.7rem] text-content-subtitle'>
+                        {formatRange(role.start, role.end)}
+                    </p>
+                </div>
+                <RoleBody role={role} index={`${index}-${roleIndex}`} />
+                {role.transition && roleIndex < roles.length - 1 && (
+                    <p className='mt-1 flex items-center gap-2 font-mono text-[0.6rem] font-semibold tracking-[0.16em] text-content-accent uppercase'>
+                        <span aria-hidden='true' className='text-neon'>
+                            &uarr;
+                        </span>
+                        {role.transition} · <span className='tabular'>{formatDate(role.start)}</span>
+                    </p>
+                )}
+            </li>
+        ))}
+    </ol>
+);
 
 const ExperienceList = () => {
     const { data, loading, error } = useJsonData('career_data.json');
@@ -11,17 +70,23 @@ const ExperienceList = () => {
     return (
         <Board columns={['Line', 'Destination — Role / Operator', 'Since / Status']}>
             {data.Experience.map((experience, index) => {
-                const ongoing = isOngoing(experience.end);
+                // Roles run newest-first, so the first is the title the row
+                // advertises and the last dates the arrival at this employer.
+                const roles = toRoles(experience);
+                const [latest] = roles;
+                const earliest = roles[roles.length - 1];
+                const ongoing = isOngoing(latest.end);
                 return (
-                    <li key={`${experience.company}-${experience.start}`}>
+                    <li key={`${experience.company}-${earliest.start}`}>
                         <DepartureRow
                             index={index}
                             letter={experience.company.charAt(0)}
-                            destination={experience.job_title}
+                            destination={latest.job_title}
                             operator={experience.company}
-                            since={formatDate(experience.start)}
+                            since={formatDate(earliest.start)}
                             status={ongoing ? 'on' : 'past'}
                             statusLabel={ongoing ? 'On Time' : 'Departed'}
+                            tag={roles.length > 1 && <Chip>{roles.length} Roles</Chip>}
                             defaultOpen={index === 0}
                             name='experience'
                         >
@@ -36,7 +101,7 @@ const ExperienceList = () => {
                                         <div className='flex flex-col'>
                                             <p className='card-accent'>{experience.type}</p>
                                             <p className='card-accent tabular'>
-                                                {formatRange(experience.start, experience.end)}
+                                                {formatRange(earliest.start, latest.end)}
                                             </p>
                                             <p className='card-fine'>{experience.location}</p>
                                         </div>
@@ -51,20 +116,11 @@ const ExperienceList = () => {
                                         <Icon icon='fa6-solid:globe' height='1.1em' width='1.1em' aria-hidden='true' />
                                     </a>
                                 </div>
-                                {experience.details.length > 0 && (
-                                    <ul className='ml-1 flex list-none flex-col gap-1.5 text-xs leading-relaxed text-content-body md:text-sm'>
-                                        {experience.details.map((detail, detailIndex) => (
-                                            <li key={`${index}-${detailIndex}`} className='flex gap-2'>
-                                                <span
-                                                    aria-hidden='true'
-                                                    className='mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-neon/70'
-                                                />
-                                                <span>{detail}</span>
-                                            </li>
-                                        ))}
-                                    </ul>
+                                {roles.length > 1 ? (
+                                    <RoleTrack roles={roles} index={index} />
+                                ) : (
+                                    <RoleBody role={latest} index={index} />
                                 )}
-                                <SkillButton skills={experience.technologies} />
                             </div>
                         </DepartureRow>
                     </li>

--- a/website/src/components/ui/primitives.tsx
+++ b/website/src/components/ui/primitives.tsx
@@ -208,6 +208,7 @@ export function DepartureRow({
     since,
     status = 'past',
     statusLabel,
+    tag,
     defaultOpen = false,
     name,
     children,
@@ -219,6 +220,9 @@ export function DepartureRow({
     since: string;
     status?: 'on' | 'past' | 'alert';
     statusLabel?: string;
+    // Service-pattern note beside the destination — "2 roles" on a stop the
+    // line calls at more than once. Omitted entirely when there is nothing to say.
+    tag?: ReactNode;
     defaultOpen?: boolean;
     // Shared name groups rows into a native exclusive accordion: opening one
     // closes the others. Degrades to independent toggles on older browsers.
@@ -236,11 +240,14 @@ export function DepartureRow({
                 {/* Board rows truncate by design, so the untruncated text has to
                     stay reachable — otherwise a long project name is simply lost. */}
                 <span className='flex min-w-0 flex-col'>
-                    <span
-                        title={destination}
-                        className='truncate font-heading text-base leading-tight font-bold tracking-wide text-content-title uppercase sm:text-lg'
-                    >
-                        {destination}
+                    <span className='flex min-w-0 items-center gap-2'>
+                        <span
+                            title={destination}
+                            className='truncate font-heading text-base leading-tight font-bold tracking-wide text-content-title uppercase sm:text-lg'
+                        >
+                            {destination}
+                        </span>
+                        {tag && <span className='shrink-0 max-sm:hidden'>{tag}</span>}
                     </span>
                     <span title={operator} className='truncate font-mono text-[0.7rem] text-neon'>
                         {operator}


### PR DESCRIPTION
## Summary
This change adds support for displaying career progression within a single employer as a promotion track. Instead of flattening multiple roles at the same company into a single entry, the experience list now displays them as a connected timeline showing the career path.

## Key Changes

- **Data structure**: Refactored Indeed career entry to use a `roles` array (newest-first) instead of flat job_title/start/end fields, with company-level metadata (location, type, logo, website) hoisted to the top level
  - Each role can now declare a `transition` label (e.g., "Promoted") to mark progression between stops
  - Updated Indeed entry to split "Lead, IT Solutions" (2023-01 to 2025-09) and "IT Support Specialist II" (2021-04 to 2023-01) into separate roles

- **Component logic**: Enhanced `ExperienceList` to normalize both flat entries and promotion tracks to a common shape
  - Added `toRoles()` helper to handle both single-role and multi-role entries
  - Extracted `RoleBody` component for shared bullet points and skills rendering
  - Added `RoleTrack` component to render a vertical timeline of roles with transition markers

- **UI improvements**:
  - Board rows now display the most recent job title and span the entire tenure at the company
  - Added a "N Roles" chip badge on rows with multiple roles (hidden on mobile)
  - Transition markers appear between roles with an upward arrow and the transition date
  - Each role maintains its own date range, details, and technologies

- **Accessibility**: Transition markers use semantic HTML with proper aria-hidden attributes for decorative elements

## Testing
- Added comprehensive test case for promotion track rendering
- Added test for optional transition markers
- Updated snapshots to reflect new DepartureRow structure with tag support

https://claude.ai/code/session_019Ttjwtk7gakhFZ6Ehdee4q