### PR TITLE
Stop test-only website changes from triggering a production deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       contents: read
     outputs:
       website: ${{ steps.filter.outputs.website }}
+      website_deployable: ${{ steps.filter.outputs.website_deployable }}
       infrastructure: ${{ steps.filter.outputs.infrastructure }}
       github: ${{ steps.filter.outputs.github }}
       web_digest: ${{ steps.digest.outputs.web }}
@@ -111,8 +112,15 @@ jobs:
             # what enqueues the cloudfrontInvalidation Lambda, so a manual run
             # with force_website is the only way to refresh the cached document
             # without committing a website change.
+            # website_deployable tracks force_website exactly, and must keep
+            # doing so: a dispatch with force_website *is* the CDN-invalidation
+            # escape hatch, and it works by re-uploading index.html. Leaving
+            # this unset here would read as false downstream and silently skip
+            # the deploy — disabling the escape hatch precisely when someone is
+            # reaching for it because the live document is stale.
             {
               printf 'website=%s\n' "$FORCE_WEBSITE"
+              printf 'website_deployable=%s\n' "$FORCE_WEBSITE"
               printf 'infrastructure=%s\n' "$FORCE_INFRA"
               echo 'github=false'
             } >> "$GITHUB_OUTPUT"
@@ -160,10 +168,37 @@ jobs:
           # Without it, changing line-length or the target version would leave
           # py-lint unrun on code it had just changed the rules for.
           match() { echo "$changed" | grep -qE "$1" && echo true || echo false; }
+
+          # Two questions, deliberately not the same one.
+          #
+          # `website` asks "could this affect the website at all", and gates the
+          # checks. It stays broad: editing a test is exactly when the tests
+          # want re-running.
+          #
+          # `website_deployable` asks the narrower "could the built bundle have
+          # changed", and gates the deploy alone. Test sources are never
+          # imported by the app entry, so editing one cannot alter a byte of the
+          # build — and a deploy is not free: the second `aws s3 sync` compares
+          # mtime, so a rebuilt index.html is re-uploaded even when byte
+          # identical, and an ObjectCreated on index.html is what enqueues the
+          # cloudfrontInvalidation Lambda. A Cypress-only edit was therefore
+          # paying for a full rebuild and a CDN invalidation to ship bytes that
+          # had not changed.
+          #
+          # Conservative on purpose, because the two ways of being wrong are not
+          # symmetric: excluding too little costs one needless deploy, while
+          # excluding too much leaves production serving a stale bundle after a
+          # real change. Only provably test-only paths belong here.
+          test_only='^website/(cypress/|cypress\.config\.js$|src/__tests__/)'
+          deployable() {
+            echo "$changed" | grep -E '^website/' | grep -qvE "$test_only" \
+              && echo true || echo false
+          }
           {
-            printf 'website=%s\n'        "$(match '^website/')"
-            printf 'infrastructure=%s\n' "$(match '^(infrastructure/|ruff\.toml$)')"
-            printf 'github=%s\n'         "$(match '^\.github/')"
+            printf 'website=%s\n'            "$(match '^website/')"
+            printf 'website_deployable=%s\n' "$(deployable)"
+            printf 'infrastructure=%s\n'     "$(match '^(infrastructure/|ruff\.toml$)')"
+            printf 'github=%s\n'             "$(match '^\.github/')"
           } >> "$GITHUB_OUTPUT"
 
       - name: Compute content digests
@@ -768,13 +803,19 @@ jobs:
     # and web-checks/web-e2e are skipped whenever the digest marker hit.
     #
     # Two things can require a deploy, hence the `||`. The obvious one is a
-    # change under website/. The other is an apply that rewrites the Actions
-    # secrets, because AWS_API_ENDPOINT is compiled into the bundle and
+    # change under website/ that the bundle could actually contain — hence
+    # website_deployable rather than website, which is broader and also covers
+    # test sources the build never sees. The other is an apply that rewrites the
+    # Actions secrets, because AWS_API_ENDPOINT is compiled into the bundle and
     # AWS_S3_BUCKET_PROD is the upload target — an infrastructure-only change
     # can invalidate the live bundle without touching a single website file.
     # Gating on the plan rather than on `infrastructure == 'true'` is what
     # keeps every Lambda edit and IAM tweak from re-uploading the whole site
     # and paying for a CloudFront invalidation it does not need.
+    #
+    # The checks are still reached on a test-only change: web-checks and web-e2e
+    # gate on the broad `website`, and this job needs them, so narrowing the
+    # deploy trigger cannot let an untested bundle ship.
     #
     # `secrets_changed` is empty when terraform was skipped, which reads as
     # false and correctly leaves website-only runs to the first clause.
@@ -783,7 +824,7 @@ jobs:
           && github.ref == 'refs/heads/main'
           && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
           && needs.changes.result == 'success'
-          && (needs.changes.outputs.website == 'true'
+          && (needs.changes.outputs.website_deployable == 'true'
               || needs.terraform.outputs.secrets_changed == 'true')
           && needs.web-checks.result != 'failure' && needs.web-checks.result != 'cancelled'
           && needs.web-e2e.result    != 'failure' && needs.web-e2e.result    != 'cancelled'


### PR DESCRIPTION
## The problem

The `website` path filter is a plain prefix match:

```bash
printf 'website=%s\n' "$(match '^website/')"
```

It cannot tell a Cypress spec from a bundle source, and `web-deploy` gated on it. So editing a test rebuilt and shipped the site — #131 changed two `.cy.js` files and nothing else, and deployed production ([run 30867860626](https://github.com/RetroHazard/CloudResume/actions/runs/30867860626)).

That isn't free. The second `aws s3 sync` compares mtime, so a freshly built `index.html` is re-uploaded even when byte-identical, and an `ObjectCreated` on `index.html` is what enqueues the `cloudfrontInvalidation` Lambda. A test-only edit paid for a full rebuild and a CDN invalidation to ship bytes that hadn't changed.

## The change

Splits the question in two rather than narrowing the existing output, because the checks and the deploy want genuinely different answers:

| Output | Scope | Gates |
|---|---|---|
| `website` | unchanged — `^website/` | `web-checks`, `web-e2e`, marker upload |
| `website_deployable` | **new** — excludes `cypress/`, `cypress.config.js`, `src/__tests__/` | `web-deploy` only |

**A build still runs the tests.** `web-deploy` has `needs: [web-checks, web-e2e]`, and those gate on the broad `website`, so narrowing the deploy trigger cannot let an untested bundle ship.

**A test edit still runs the tests**, since `website` is untouched — which is the behaviour worth keeping.

## Why the exclusion list is short

The two ways of being wrong aren't symmetric: excluding too little costs one needless deploy, while excluding too much leaves production serving a **stale bundle** after a real change. So only paths the app entry provably never imports are excluded. Everything else — `vite.config.js`, `package.json`, `index.html`, `public/`, `scripts/`, and a source file merely *named* like a test — still deploys.

`website_deployable` also tracks `force_website` on a `workflow_dispatch`. That's load-bearing: the dispatch is the CDN-invalidation escape hatch and works by re-uploading `index.html`, so leaving the output unset there would read as `false` downstream and silently skip the deploy exactly when someone reaches for it because the live document is stale.

## Verification

The filter logic was extracted and run against 17 path scenarios under the same `set -euo pipefail` as the real step — all pass:

| Changed paths | `website` | `website_deployable` |
|---|---|---|
| `cypress/e2e/api-live.cy.js` | true | **false** |
| `cypress/e2e/*.cy.js` + `cypress/support/e2e.js` | true | **false** |
| `cypress.config.js` | true | **false** |
| `src/__tests__/Home.test.js` + snapshots | true | **false** |
| all three test groups mixed | true | **false** |
| `src/components/NavBar.jsx` | true | true |
| test file **+** real source | true | true |
| `vite.config.js` | true | true |
| `package.json` | true | true |
| `index.html` | true | true |
| `public/files/cv.pdf` | true | true |
| `scripts/fetch-contributions.mjs` | true | true |
| `src/utils/testHelpers.js` | true | true |
| `src/cypressThing.js` | true | true |
| no-base fallback (`website/`) | true | true |
| `infrastructure/main.tf` only | false | false |
| `.github/workflows/ci.yml` only | false | false |

The last two "true" source rows matter: the regex is directory-anchored, so a source file with `test` or `cypress` in its *name* is not mistaken for a test.

## Test plan

- [x] Filter logic verified against 17 path scenarios, including `set -e` behaviour and the `$GITHUB_OUTPUT` write
- [ ] `Workflow lint` (actionlint + shellcheck) passes
- [ ] This PR touches only `.github/`, so `website` is `false` and both `web-checks`/`web-e2e` skip — expected
- [ ] After merge, on this push: `Deploy website` **skipped** (workflow-only change, `website_deployable=false`), and consequently `Production smoke test` skipped
- [ ] On the next real source change: `Deploy website` runs as before

Note the last two together are the point — this PR's own merge is a live demonstration, since a `.github/`-only change should not deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XM4Qp1kdXDrNAaLbX1VrnB)_